### PR TITLE
Data passing to GPU memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ ui_*.h
 *.sln
 *.vcxproj
 *.filters
+
+# Data files
+data/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@
 // Has to be initialized before application gets created.
 void setupGlobalRenderingSettings() {
     QSurfaceFormat format{};
-    format.setVersion(4, 3);
+    format.setVersion(4, 5);
     format.setProfile(QSurfaceFormat::CoreProfile);
     format.setOptions(QSurfaceFormat::DebugContext);
     format.setSwapInterval(1);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -29,7 +29,11 @@ MainWindow::MainWindow(QWidget *parent)
     connect(mUi->actionData_Manager, &QAction::triggered, this, [&](){
         addWidget(createWrapperWidget(new DataWidget{mGlobalVolume.get(), this}, "Data Manager"));
     });
+
+    // Manually create 2 widgets:
+    // NOTE: For datawidget to be able to create a volume, a render widget must be present. Else OpenGL crashes.
     mUi->actionData_Manager->trigger();
+    mUi->action2D_Viewport->trigger();
 
     mGlobalViewMatrix.setToIdentity();
 }

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -102,7 +102,10 @@ void Renderer::paintGL() {
     shader.bind();
     shader.setUniformValue("MVP", MVP);
 
+    mMainWindow->mGlobalVolume->bind(1);
+
     mScreenVAO->draw();
+    mMainWindow->mGlobalVolume->unbind();
 
     ++mFrameCount;
 }

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -4,9 +4,6 @@
 #include "shaders/shadermanager.h"
 #include "mainwindow.h"
 #include "volume.h"
-#include <QOpenGLContext>
-#include <QOpenGLFunctions_4_5_Core>
-#include <QTime>
 
 ScreenSpacedBuffer::ScreenSpacedBuffer() {
     initializeOpenGLFunctions();
@@ -83,6 +80,7 @@ void Renderer::initializeGL() {
     initializeOpenGLFunctions();
 
     // OpenGL Debugger callback:
+    // TODO: Very explicit so hould be removed (or silenced) in release
     static auto debugMessageCallback = [](
             GLenum source,
             GLenum type,
@@ -118,9 +116,6 @@ void Renderer::paintGL() {
     auto& shader = shaderProgram("screen");
     shader.bind();
     shader.setUniformValue("MVP", MVP);
-
-    const auto time = QTime::currentTime();
-    shader.setUniformValue("time", static_cast<float>(time.msec()) * 0.001f);
 
     // Volume guard automatically binds and unbinds. :)
     const auto volumeGuard = mMainWindow->mGlobalVolume->guard(0);

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -4,6 +4,9 @@
 #include "shaders/shadermanager.h"
 #include "mainwindow.h"
 #include "volume.h"
+#include <QOpenGLContext>
+#include <QOpenGLFunctions_4_5_Core>
+#include <QTime>
 
 ScreenSpacedBuffer::ScreenSpacedBuffer() {
     initializeOpenGLFunctions();
@@ -116,8 +119,11 @@ void Renderer::paintGL() {
     shader.bind();
     shader.setUniformValue("MVP", MVP);
 
+    const auto time = QTime::currentTime();
+    shader.setUniformValue("time", static_cast<float>(time.msec()) * 0.001f);
+
     // Volume guard automatically binds and unbinds. :)
-    const auto volumeGuard = mMainWindow->mGlobalVolume->guard(1);
+    const auto volumeGuard = mMainWindow->mGlobalVolume->guard(0);
 
     mScreenVAO->draw();
 

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -3,6 +3,7 @@
 #include <QElapsedTimer>
 #include "shaders/shadermanager.h"
 #include "mainwindow.h"
+#include "volume.h"
 
 ScreenSpacedBuffer::ScreenSpacedBuffer() {
     initializeOpenGLFunctions();
@@ -77,6 +78,19 @@ double Renderer::getFramesPerSecond() {
 
 void Renderer::initializeGL() {
     initializeOpenGLFunctions();
+
+    // OpenGL Debugger callback:
+    static auto debugMessageCallback = [](
+            GLenum source,
+            GLenum type,
+            GLuint id,
+            GLenum severity,
+            GLsizei length,
+            const GLchar *message,
+            const void *userParam) {
+        std::cout << "GL DEBUG: " << message << std::endl;
+    };
+    glDebugMessageCallback(debugMessageCallback, nullptr);
 
     mScreenVAO = std::make_unique<ScreenSpacedBuffer>();
 

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -102,10 +102,10 @@ void Renderer::paintGL() {
     shader.bind();
     shader.setUniformValue("MVP", MVP);
 
-    mMainWindow->mGlobalVolume->bind(1);
+    // Volume guard automatically binds and unbinds. :)
+    const auto volumeGuard = mMainWindow->mGlobalVolume->guard(1);
 
     mScreenVAO->draw();
-    mMainWindow->mGlobalVolume->unbind();
 
     ++mFrameCount;
 }

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -2,7 +2,7 @@
 #define RENDERER_H
 
 #include <QOpenGLWidget>
-#include <QOpenGLFunctions_4_3_Core>
+#include <QOpenGLFunctions_4_5_Core>
 #include <QOpenGLShaderProgram>
 #include <QMatrix4x4>
 #include <QElapsedTimer>
@@ -11,7 +11,7 @@
 /**
  * @brief Helper class to draw a screen spaced quad
  */
-class ScreenSpacedBuffer : protected QOpenGLFunctions_4_3_Core {
+class ScreenSpacedBuffer : protected QOpenGLFunctions_4_5_Core {
 private:
     GLuint mVAO, mVBO;
 
@@ -27,7 +27,7 @@ public:
 
 class MainWindow;
 
-class Renderer : public QOpenGLWidget, protected QOpenGLFunctions_4_3_Core
+class Renderer : public QOpenGLWidget, protected QOpenGLFunctions_4_5_Core
 {
     Q_OBJECT
 public:

--- a/src/volume.cpp
+++ b/src/volume.cpp
@@ -3,6 +3,7 @@
 #include <QDataStream>
 #include <QDebug>
 #include <vector>
+#include <cmath>
 
 Volume::Volume()
 {

--- a/src/volume.cpp
+++ b/src/volume.cpp
@@ -2,7 +2,6 @@
 #include <QFile>
 #include <QDataStream>
 #include <QDebug>
-#include <vector>
 #include <cmath>
 
 Volume::Volume()

--- a/src/volume.cpp
+++ b/src/volume.cpp
@@ -59,7 +59,7 @@ void Volume::bind(GLuint binding) {
 
     m_binding = binding;
     glActiveTexture(GL_TEXTURE0 + binding);
-    glBindTexture(GL_TEXTURE_2D, m_texBuffer);
+    glBindTexture(GL_TEXTURE_3D, m_texBuffer);
 }
 
 void Volume::unbind() {
@@ -67,7 +67,7 @@ void Volume::unbind() {
         return;
     
     glActiveTexture(GL_TEXTURE0 + *m_binding);
-    glBindTexture(GL_TEXTURE_2D, 0);
+    glBindTexture(GL_TEXTURE_3D, 0);
     m_binding = std::nullopt;
 }
 
@@ -75,17 +75,18 @@ void Volume::generateTexture() {
     initializeOpenGLFunctions();
 
     glGenTextures(1, &m_texBuffer);
-    glBindTexture(GL_TEXTURE_2D, m_texBuffer);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RED, m_width, m_height, 0, GL_RED, GL_FLOAT, m_volumeData.data() + m_volumeData.size() / 2);
+    glBindTexture(GL_TEXTURE_3D, m_texBuffer);
+    glTexImage3D(GL_TEXTURE_3D, 0, GL_RED, m_width, m_height, m_depth, 0, GL_RED, GL_FLOAT, m_volumeData.data());
 
     // Min and mag filter: bilinear scaling
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     // Wrap mode: just clamp to edge since edge is 0
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
 
-    glBindTexture(GL_TEXTURE_2D, 0);
+    glBindTexture(GL_TEXTURE_3D, 0);
     m_texInitiated = true;
 }
 

--- a/src/volume.cpp
+++ b/src/volume.cpp
@@ -39,7 +39,7 @@ bool Volume::loadData(const QString &fileName)
     }
 
     // Convert data to floating points in range [0,1]
-    m_volumeData.resize(volumeSize, 0.f);
+    m_volumeData.reserve(volumeSize);
     for (const auto& val : volumeRaw) {
         // Original data uses 12 of 16 bits, giving the data range of
         // [0, 2^12]. Therefore divide by 2^12 to give the range [0, 1].

--- a/src/volume.cpp
+++ b/src/volume.cpp
@@ -21,14 +21,14 @@ bool Volume::loadData(const QString &fileName)
     QDataStream stream(&file);
     stream.setByteOrder(QDataStream::LittleEndian);
 
-    unsigned short width = 0, height = 0, depth = 0;
-    stream >> width >> height >> depth;
+    // unsigned short width = 0, height = 0, depth = 0;
+    stream >> m_width >> m_height >> m_depth;
 
-    qDebug() << "Width:" << width;
-    qDebug() << "Height:" << height;
-    qDebug() << "Depth:" << depth;
+    qDebug() << "Width:" << m_width;
+    qDebug() << "Height:" << m_height;
+    qDebug() << "Depth:" << m_depth;
 
-    int volumeSize = int(width)*int(height)*int(depth);
+    int volumeSize = int(m_width)*int(m_height)*int(m_depth);
     m_volumeData.resize(volumeSize);
 
     if (stream.readRawData(reinterpret_cast<char*>(m_volumeData.data()),volumeSize*sizeof (unsigned short)) != volumeSize*sizeof (unsigned short))
@@ -36,6 +36,47 @@ bool Volume::loadData(const QString &fileName)
         return false;
     }
 
+    generateTexture();
 
     return true;
+}
+
+void Volume::bind(GLuint binding) {
+    if (!m_texInitiated)
+        return;
+
+    m_binding = binding;
+    glActiveTexture(GL_TEXTURE0 + binding);
+    glBindTexture(GL_TEXTURE_2D, m_texBuffer);
+}
+
+void Volume::unbind() {
+    if (!m_texInitiated || !m_binding)
+        return;
+    
+    glActiveTexture(GL_TEXTURE0 + *m_binding);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    m_binding = std::nullopt;
+}
+
+void Volume::generateTexture() {
+    initializeOpenGLFunctions();
+
+    glGenTextures(1, &m_texBuffer);
+    glBindTexture(GL_TEXTURE_2D, m_texBuffer);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_width, m_height, 0, GL_RED, GL_UNSIGNED_SHORT, m_volumeData.data());
+    // Min and mag filter: bilinear scaling
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    // Wrap mode: just clamp to edge since edge is 0
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    glBindTexture(GL_TEXTURE_2D, 0);
+    m_texInitiated = true;
+}
+
+Volume::~Volume() {
+    if (m_texInitiated)
+        glDeleteTextures(1, &m_texBuffer);
 }

--- a/src/volume.h
+++ b/src/volume.h
@@ -27,6 +27,23 @@ private:
     void generateTexture();
 
 public:
+    /**
+     * @brief Helper class that binds the texture on construction and unbinds on destruction.
+     */
+    class Guard {
+    private:
+        Volume* m_vol{nullptr};
+
+    public:
+        Guard(const Guard&) = delete;
+        Guard(Volume* v, GLuint binding = 0)
+            : m_vol{v}
+            { v->bind(binding); }
+        ~Guard() { m_vol->unbind(); }
+    };
+
+    Guard guard(GLuint binding = 0) { return Guard{this, binding}; }
+
     ~Volume();
 };
 

--- a/src/volume.h
+++ b/src/volume.h
@@ -1,8 +1,10 @@
 #ifndef VOLUME_H
 #define VOLUME_H
 #include <QObject>
+#include <QOpenGLFunctions_4_3_Core>
+#include <optional>
 
-class Volume : public QObject
+class Volume : public QObject, protected QOpenGLFunctions_4_3_Core
 {
     Q_OBJECT
 public:
@@ -10,8 +12,21 @@ public:
 
     bool loadData(const QString &fileName);
 
+    void bind(GLuint binding = 0);
+    void unbind();
+
 private:
+    unsigned short m_width{0}, m_height{0}, m_depth{0};
+
     QVector<unsigned short> m_volumeData;
+    GLuint m_texBuffer;
+    bool m_texInitiated{false};
+    std::optional<GLuint> m_binding{std::nullopt};
+
+    void generateTexture();
+
+public:
+    ~Volume();
 };
 
 #endif // VOLUME_H

--- a/src/volume.h
+++ b/src/volume.h
@@ -3,6 +3,7 @@
 #include <QObject>
 #include <QOpenGLFunctions_4_3_Core>
 #include <optional>
+#include <vector>
 
 class Volume : public QObject, protected QOpenGLFunctions_4_3_Core
 {
@@ -18,7 +19,7 @@ public:
 private:
     unsigned short m_width{0}, m_height{0}, m_depth{0};
 
-    QVector<unsigned short> m_volumeData;
+    std::vector<float> m_volumeData;
     GLuint m_texBuffer;
     bool m_texInitiated{false};
     std::optional<GLuint> m_binding{std::nullopt};

--- a/src/volume.h
+++ b/src/volume.h
@@ -1,11 +1,11 @@
 #ifndef VOLUME_H
 #define VOLUME_H
 #include <QObject>
-#include <QOpenGLFunctions_4_3_Core>
+#include <QOpenGLFunctions_4_5_Core>
 #include <optional>
 #include <vector>
 
-class Volume : public QObject, protected QOpenGLFunctions_4_3_Core
+class Volume : public QObject, protected QOpenGLFunctions_4_5_Core
 {
     Q_OBJECT
 public:


### PR DESCRIPTION
When loading data, the volume class now also generates a 3d texture for use on the GPU. Currently only the global volume is available to viewports.