### PR TITLE
Datawidget popup + bugfixes

### DIFF
--- a/src/datawidget.cpp
+++ b/src/datawidget.cpp
@@ -43,9 +43,8 @@ void DataWidget::on_listView_doubleClicked(const QModelIndex &index)
     // This is the absolute file path to the file double clicked
     QString filePath = filemodel->fileInfo(index).absoluteFilePath();
 
-    if(filemodel->fileInfo(index).suffix()=="dat") {
+    if(filemodel->fileInfo(index).suffix()=="dat" && m_volume->loadData(filePath)) {
         qInfo() << "Successfully loaded file at " + filePath;
-        m_volume->loadData(filePath);
         this->close();
     } else {
         //Not supported file type

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -47,7 +47,9 @@ MainWindow::MainWindow(QWidget *parent)
 }
 
 void MainWindow::addWidget(DockWrapper* widget) {
+#ifndef NDEBUG
     std::cout << "Widget added!" << std::endl;
+#endif
 
     // If the widget has a menu, add dock controls to the menu
     // if (auto* menuwidget = dynamic_cast<IMenu*>(widget)) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -28,14 +28,13 @@ MainWindow::MainWindow(QWidget *parent)
     connect(mUi->action3D_Viewport, &QAction::triggered, this, [&](){
         addWidget(createWrapperWidget(new Viewport3D{this}, "3D Viewport"));
     });
-    connect(mUi->actionData_Manager, &QAction::triggered, this, [&](){
-        addWidget(createWrapperWidget(new DataWidget{mGlobalVolume.get(), this}, "Data Manager"));
-    });
+    connect(mUi->actionOpen, &QAction::triggered, this, [&](){ loadData(); });
 
-    // Manually create 2 widgets:
+    // Manually create a rendering widget:
     // NOTE: For datawidget to be able to create a volume, a render widget must be present. Else OpenGL crashes.
-    mUi->actionData_Manager->trigger();
     mUi->action2D_Viewport->trigger();
+
+    loadData();
 
     mGlobalViewMatrix.setToIdentity();
 
@@ -61,6 +60,13 @@ void MainWindow::addWidget(DockWrapper* widget) {
 
     layoutDockWidget(widget);
     mWidgets.push_back(widget);
+}
+
+DataWidget* MainWindow::loadData(Volume* targetVolume) {
+    auto widget = new DataWidget{targetVolume != nullptr ? targetVolume : mGlobalVolume.get(), this};
+    widget->setWindowFlag(Qt::Window);
+    widget->show();
+    return widget;
 }
 
 DockWrapper* MainWindow::createWrapperWidget(QWidget* widget, const QString& title) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -14,7 +14,7 @@
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent),
     mUi{new Ui::MainWindow},
-    mGlobalVolume{std::make_unique<Volume>()}
+    mGlobalVolume{std::make_shared<Volume>()}
 {
     mUi->setupUi(this);
     // QMainWindow requires a cental widget but we don't use it.
@@ -28,7 +28,7 @@ MainWindow::MainWindow(QWidget *parent)
     connect(mUi->action3D_Viewport, &QAction::triggered, this, [&](){
         addWidget(createWrapperWidget(new Viewport3D{this}, "3D Viewport"));
     });
-    connect(mUi->actionOpen, &QAction::triggered, this, [&](){ loadData(); });
+    connect(mUi->actionOpen, &QAction::triggered, this, &MainWindow::load);
 
     // Manually create a rendering widget:
     // NOTE: For datawidget to be able to create a volume, a render widget must be present. Else OpenGL crashes.
@@ -67,6 +67,10 @@ DataWidget* MainWindow::loadData(Volume* targetVolume) {
     widget->setWindowFlag(Qt::Window);
     widget->show();
     return widget;
+}
+
+void MainWindow::load() {
+    loadData();
 }
 
 DockWrapper* MainWindow::createWrapperWidget(QWidget* widget, const QString& title) {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -30,7 +30,7 @@ public:
 
     // Global camera matrix for all render-widgets
     QMatrix4x4 mGlobalViewMatrix;
-    std::unique_ptr<Volume> mGlobalVolume;
+    std::shared_ptr<Volume> mGlobalVolume;
     std::vector<QDockWidget*> mWidgets;
     std::vector<QShortcut*> mShortcuts;
 
@@ -45,6 +45,10 @@ public slots:
      * @return DataWidget* A pointer to the created widget
      */
     DataWidget* loadData(Volume* targetVolume = nullptr);
+
+private slots:
+    // Helper slot for button.
+    void load();
 
 private:
     std::unique_ptr<Ui::MainWindow> mUi;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -13,6 +13,7 @@ class QWidget;
 class Volume;
 class DockWrapper;
 class QShortcut;
+class DataWidget;
 
 QT_BEGIN_NAMESPACE
 namespace Ui { class MainWindow; }
@@ -34,6 +35,16 @@ public:
     std::vector<QShortcut*> mShortcuts;
 
     ~MainWindow();
+
+public slots:
+    /**
+     * @brief Open up a data loading popup window
+     * Opens up a data widget as a data loading popup window
+     * that stores it's loaded data into targetVolume.
+     * @param targetVolume The target volume to load data into. If nullptr it will use the global volume.
+     * @return DataWidget* A pointer to the created widget
+     */
+    DataWidget* loadData(Volume* targetVolume = nullptr);
 
 private:
     std::unique_ptr<Ui::MainWindow> mUi;

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -45,10 +45,16 @@
      </property>
      <addaction name="action2D_Viewport"/>
      <addaction name="action3D_Viewport"/>
-     <addaction name="actionData_Manager"/>
     </widget>
     <addaction name="menuAdd"/>
    </widget>
+   <widget class="QMenu" name="menuData">
+    <property name="title">
+     <string>File</string>
+    </property>
+    <addaction name="actionOpen"/>
+   </widget>
+   <addaction name="menuData"/>
    <addaction name="menuLayout"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
@@ -70,6 +76,14 @@
   <action name="actionData_Manager">
    <property name="text">
     <string>Data Manager</string>
+   </property>
+  </action>
+  <action name="actionOpen">
+   <property name="text">
+    <string>Open</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+O</string>
    </property>
   </action>
  </widget>

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -79,8 +79,8 @@ double Renderer::getFramesPerSecond() {
 void Renderer::initializeGL() {
     initializeOpenGLFunctions();
 
+#ifndef NDEBUG
     // OpenGL Debugger callback:
-    // TODO: Very explicit so hould be removed (or silenced) in release
     static auto debugMessageCallback = [](
             GLenum source,
             GLenum type,
@@ -92,6 +92,7 @@ void Renderer::initializeGL() {
         std::cout << "GL DEBUG: " << message << std::endl;
     };
     glDebugMessageCallback(debugMessageCallback, nullptr);
+#endif
 
     mScreenVAO = std::make_unique<ScreenSpacedBuffer>();
 

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -110,15 +110,16 @@ void Renderer::paintGL() {
     glClear(GL_COLOR_BUFFER_BIT);
 
     mPrivateViewMatrix.rotate(10.0f * deltaTime, QVector3D{0.5f, 1.f, 0.f});
-    const auto& viewMatrix = mUseGlobalMatrix ? mMainWindow->mGlobalViewMatrix : mPrivateViewMatrix;
+    const auto& viewMatrix = getViewMatrix();
     const auto MVP = (mPerspectiveMatrix * viewMatrix).inverted();
+    const auto& volume = getVolume();
 
     auto& shader = shaderProgram("screen");
     shader.bind();
     shader.setUniformValue("MVP", MVP);
 
     // Volume guard automatically binds and unbinds. :)
-    const auto volumeGuard = mMainWindow->mGlobalVolume->guard(0);
+    const auto volumeGuard = volume->guard(0);
 
     mScreenVAO->draw();
 
@@ -129,6 +130,14 @@ void Renderer::resizeGL(int w, int h) {
     const auto aspectRatio = static_cast<float>(w) / h;
     mPerspectiveMatrix.setToIdentity();
     mPerspectiveMatrix.perspective(45.f, aspectRatio, 0.1f, 1000.f);
+}
+
+const QMatrix4x4& Renderer::getViewMatrix() const {
+    return mUseGlobalMatrix ? mMainWindow->mGlobalViewMatrix : mPrivateViewMatrix;
+}
+
+std::shared_ptr<Volume> Renderer::getVolume() const {
+    return mUseGlobalVolume ? mMainWindow->mGlobalVolume : mPrivateVolume;
 }
 
 void Renderer::scheduleRender() {

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -26,6 +26,7 @@ public:
 };
 
 class MainWindow;
+class Volume;
 
 class Renderer : public QOpenGLWidget, protected QOpenGLFunctions_4_5_Core
 {
@@ -35,6 +36,15 @@ public:
 
     double getFramesPerSecond();
 
+    // Whether to use widgets camera or global camera
+    bool mUseGlobalMatrix{false};
+    // Render-widgets own camera matrix. If not using global camera matrix, render-widgets use this one.
+    QMatrix4x4 mPrivateViewMatrix;
+
+    // Whether to use widgets volume data or global volume data
+    bool mUseGlobalVolume{true};
+    std::shared_ptr<Volume> mPrivateVolume;
+
     ~Renderer();
 
 protected:
@@ -42,14 +52,14 @@ protected:
     void paintGL() override;
     void resizeGL(int w, int h) override;
 
+    virtual const QMatrix4x4& getViewMatrix() const; 
+    virtual std::shared_ptr<Volume> getVolume() const;
+
     MainWindow* mMainWindow;
 
     // Screen Spaced vertex array
     std::unique_ptr<ScreenSpacedBuffer> mScreenVAO;
-    // Render-widgets own camera matrix. If not using global camera matrix, render-widgets use this one.
-    QMatrix4x4 mPrivateViewMatrix;
-    // Whether to use widgets camera or global camera
-    bool mUseGlobalMatrix{false};
+
     QMatrix4x4 mPerspectiveMatrix;
 
     QElapsedTimer mFrameTimer, mAliveTimer;

--- a/src/renderer2d.cpp
+++ b/src/renderer2d.cpp
@@ -45,7 +45,9 @@ void Renderer2D::paintGL() {
     const auto time = mFrameTimer.elapsed() * 0.001f;
 
     auto& shader = shaderProgram("slice");
+#ifndef NDEBUG
     if (!shader.isLinked()) return;
+#endif
 
     shader.bind();
     shader.setUniformValue("MVP", MVP);

--- a/src/renderer2d.cpp
+++ b/src/renderer2d.cpp
@@ -39,9 +39,9 @@ void Renderer2D::paintGL() {
 
     glClear(GL_COLOR_BUFFER_BIT);
 
-    const auto& viewMatrix = mUseGlobalMatrix ? mMainWindow->mGlobalViewMatrix : mPrivateViewMatrix;
+    const auto& viewMatrix = getViewMatrix();
     const auto MVP = (mPerspectiveMatrix * viewMatrix).inverted();
-    const auto& volume = mMainWindow->mGlobalVolume;
+    const auto& volume = getVolume();
     const auto time = mFrameTimer.elapsed() * 0.001f;
 
     auto& shader = shaderProgram("slice");
@@ -50,6 +50,7 @@ void Renderer2D::paintGL() {
     shader.bind();
     shader.setUniformValue("MVP", MVP);
     shader.setUniformValue("volumeScale", volume->volumeScale());
+    shader.setUniformValue("volumeSpacing", volume->volumeSpacing());
     shader.setUniformValue("time", time);
 
     // Volume guard automatically binds and unbinds. :)

--- a/src/renderer3d.cpp
+++ b/src/renderer3d.cpp
@@ -44,9 +44,9 @@ void Renderer3D::paintGL() {
     glClear(GL_COLOR_BUFFER_BIT);
 
     mPrivateViewMatrix.rotate(10.0f * deltaTime, QVector3D{0.5f, 1.f, 0.f});
-    const auto& viewMatrix = mUseGlobalMatrix ? mMainWindow->mGlobalViewMatrix : mPrivateViewMatrix;
+    const auto& viewMatrix = getViewMatrix();
     const auto MVP = (mPerspectiveMatrix * viewMatrix).inverted();
-    const auto& volume = mMainWindow->mGlobalVolume;
+    const auto& volume = getVolume();
 
     auto& shader = shaderProgram("volume");
     if (!shader.isLinked()) return;

--- a/src/renderer3d.cpp
+++ b/src/renderer3d.cpp
@@ -46,7 +46,9 @@ void Renderer3D::paintGL() {
     const auto& volume = getVolume();
 
     auto& shader = shaderProgram("volume");
+#ifndef NDEBUG
     if (!shader.isLinked()) return;
+#endif
 
     shader.bind();
     shader.setUniformValue("MVP", MVP);

--- a/src/shaders/slice-image.fs
+++ b/src/shaders/slice-image.fs
@@ -5,6 +5,7 @@ in vec2 fragCoord;
 uniform mat4 MVP = mat4(1.0);
 layout(binding = 0) uniform sampler3D volume;
 uniform vec3 volumeScale;
+uniform vec3 volumeSpacing = vec3(1., 1., 1.);
 uniform float time;
 
 out vec4 fragColor;
@@ -16,7 +17,10 @@ void main() {
 
     const float sTime = fract(time * 0.1);
 
-    const float grayScale = texture(volume, vec3(uv, sTime)).r;
+    vec3 texCoords = vec3(uv, sTime);
+    // Apply volume spacing: [0, 1] -> [-0.5, 0.5] -> volumeSpacing * [-0.5, 0.5] -> 0.5 + volumeSpacing * [-0.5, 0.5] 
+    texCoords = volumeSpacing * (texCoords - 0.5) + 0.5;
+    const float grayScale = texture(volume, texCoords).r;
 
     fragColor = vec4(vec3(grayScale), 1.);
 }

--- a/src/viewport2d.cpp
+++ b/src/viewport2d.cpp
@@ -46,7 +46,7 @@ void Viewport2D::load() {
             mainwindow->loadData(mRenderer->mPrivateVolume.get());
             connect(mRenderer->mPrivateVolume.get(), &Volume::loaded, this, [&](){
                 mRemoveVolumeAction->setChecked(false);
-                mRenderer->mUseGlobalVolume = true;
+                mRenderer->mUseGlobalVolume = false;
             });
         }
     }

--- a/src/viewport2d.cpp
+++ b/src/viewport2d.cpp
@@ -5,6 +5,8 @@
 #include <QMenuBar>
 #include <QSizePolicy>
 #include <QDockWidget>
+#include "mainwindow.h"
+#include "volume.h"
 
 Viewport2D::Viewport2D(QWidget *parent) :
     QWidget{parent}, IMenu{this}
@@ -18,7 +20,8 @@ Viewport2D::Viewport2D(QWidget *parent) :
 
     // Menubar:
     auto datamenu = mMenuBar->addMenu("Data");
-    datamenu->addAction("Load");
+    auto openAction = datamenu->addAction("Open");
+    connect(openAction, &QAction::triggered, this, &Viewport2D::load);
     mLayout->addWidget(mMenuBar);
 
     // OpenGL Render Widget:
@@ -29,3 +32,14 @@ Viewport2D::Viewport2D(QWidget *parent) :
 }
 
 Viewport2D::~Viewport2D() = default;
+
+void Viewport2D::load() {
+    if (parentWidget()) {
+        auto mainwindow = dynamic_cast<MainWindow*>(parentWidget()->parentWidget());
+        if (mainwindow) {
+            mRenderer->mUseGlobalVolume = true;
+            mRenderer->mPrivateVolume = std::make_shared<Volume>();
+            mainwindow->loadData(mRenderer->mPrivateVolume.get());
+        }
+    }
+}

--- a/src/viewport2d.h
+++ b/src/viewport2d.h
@@ -21,8 +21,11 @@ private:
     Renderer* mRenderer{nullptr};
     QVBoxLayout* mLayout{nullptr};
 
+    QAction* mRemoveVolumeAction{nullptr};
+
 private slots:
     void load();
+    void removeVolume(bool bState);
 
 };
 

--- a/src/viewport2d.h
+++ b/src/viewport2d.h
@@ -7,6 +7,7 @@
 
 class Renderer;
 class QVBoxLayout;
+class QAction;
 
 class Viewport2D : public QWidget, public IMenu
 {
@@ -19,6 +20,9 @@ public:
 private:
     Renderer* mRenderer{nullptr};
     QVBoxLayout* mLayout{nullptr};
+
+private slots:
+    void load();
 
 };
 

--- a/src/viewport3d.cpp
+++ b/src/viewport3d.cpp
@@ -16,6 +16,10 @@ Viewport3D::Viewport3D(QWidget *parent) :
     datamenu->addAction("Load");
     auto openAction = datamenu->addAction("Open");
     connect(openAction, &QAction::triggered, this, &Viewport3D::load);
+    mRemoveVolumeAction = datamenu->addAction("Use global volume");
+    mRemoveVolumeAction->setCheckable(true);
+    mRemoveVolumeAction->setChecked(true);
+    connect(mRemoveVolumeAction, &QAction::triggered, this, &Viewport3D::removeVolume);
     
     mLayout->addWidget(mMenuBar);
 
@@ -32,9 +36,25 @@ void Viewport3D::load() {
     if (parentWidget()) {
         auto mainwindow = dynamic_cast<MainWindow*>(parentWidget()->parentWidget());
         if (mainwindow) {
-            mRenderer->mUseGlobalVolume = true;
             mRenderer->mPrivateVolume = std::make_shared<Volume>();
             mainwindow->loadData(mRenderer->mPrivateVolume.get());
+            connect(mRenderer->mPrivateVolume.get(), &Volume::loaded, this, [&](){
+                mRemoveVolumeAction->setChecked(false);
+                mRenderer->mUseGlobalVolume = true;
+            });
         }
     }
+}
+
+void Viewport3D::removeVolume(bool bState) {
+    // If user manually toggles it off, it should'nt do anything.
+    if (!bState) {
+        // Just enable the bool again. >:)
+        mRemoveVolumeAction->setChecked(true);
+        return;
+    }
+
+    mRenderer->mUseGlobalVolume = true;
+    // Delete ptr by replacing it with nothing
+    mRenderer->mPrivateVolume = {};
 }

--- a/src/viewport3d.cpp
+++ b/src/viewport3d.cpp
@@ -1,6 +1,8 @@
 #include "viewport3d.h"
 #include "renderer3d.h"
 #include <QVBoxLayout>
+#include "mainwindow.h"
+#include "volume.h"
 
 Viewport3D::Viewport3D(QWidget *parent) :
     QWidget{parent}, IMenu{this}
@@ -12,6 +14,9 @@ Viewport3D::Viewport3D(QWidget *parent) :
     // Menubar:
     auto datamenu = mMenuBar->addMenu("Data");
     datamenu->addAction("Load");
+    auto openAction = datamenu->addAction("Open");
+    connect(openAction, &QAction::triggered, this, &Viewport3D::load);
+    
     mLayout->addWidget(mMenuBar);
 
     // OpenGL Render Widget:
@@ -22,3 +27,14 @@ Viewport3D::Viewport3D(QWidget *parent) :
 }
 
 Viewport3D::~Viewport3D() = default;
+
+void Viewport3D::load() {
+    if (parentWidget()) {
+        auto mainwindow = dynamic_cast<MainWindow*>(parentWidget()->parentWidget());
+        if (mainwindow) {
+            mRenderer->mUseGlobalVolume = true;
+            mRenderer->mPrivateVolume = std::make_shared<Volume>();
+            mainwindow->loadData(mRenderer->mPrivateVolume.get());
+        }
+    }
+}

--- a/src/viewport3d.cpp
+++ b/src/viewport3d.cpp
@@ -13,7 +13,6 @@ Viewport3D::Viewport3D(QWidget *parent) :
 
     // Menubar:
     auto datamenu = mMenuBar->addMenu("Data");
-    datamenu->addAction("Load");
     auto openAction = datamenu->addAction("Open");
     connect(openAction, &QAction::triggered, this, &Viewport3D::load);
     mRemoveVolumeAction = datamenu->addAction("Use global volume");
@@ -40,7 +39,7 @@ void Viewport3D::load() {
             mainwindow->loadData(mRenderer->mPrivateVolume.get());
             connect(mRenderer->mPrivateVolume.get(), &Volume::loaded, this, [&](){
                 mRemoveVolumeAction->setChecked(false);
-                mRenderer->mUseGlobalVolume = true;
+                mRenderer->mUseGlobalVolume = false;
             });
         }
     }

--- a/src/viewport3d.h
+++ b/src/viewport3d.h
@@ -19,6 +19,9 @@ public:
 private:
     Renderer3D* mRenderer{nullptr};
     QVBoxLayout* mLayout{nullptr};
+
+private slots:
+    void load();
 };
 
 #endif // VIEWPORT3D_H

--- a/src/viewport3d.h
+++ b/src/viewport3d.h
@@ -20,8 +20,12 @@ private:
     Renderer3D* mRenderer{nullptr};
     QVBoxLayout* mLayout{nullptr};
 
+    QAction* mRemoveVolumeAction{nullptr};
+
 private slots:
     void load();
+    void removeVolume(bool bState);
+    
 };
 
 #endif // VIEWPORT3D_H

--- a/src/volume.cpp
+++ b/src/volume.cpp
@@ -51,6 +51,9 @@ bool Volume::loadData(const QString &fileName)
 
     generateTexture();
 
+    // Fire "loaded" events:
+    loaded();
+
     return true;
 }
 

--- a/src/volume.cpp
+++ b/src/volume.cpp
@@ -125,6 +125,10 @@ bool Volume::loadINI(const QString &fileName) {
             m_spacing.setZ(std::stof(dataCatagory.get("oldDat Spacing Z")));
     }
 
+    // Normalize spacing (to make it easier for shaders)
+    const auto largest = std::max({m_spacing.x(), m_spacing.y(), m_spacing.z()});
+    m_spacing /= largest;
+
     return true;
 }
 

--- a/src/volume.h
+++ b/src/volume.h
@@ -19,6 +19,9 @@ public:
 
     QVector3D volumeScale() const { return m_scale; }
 
+signals:
+    void loaded();
+
 private:
     unsigned short m_width{0}, m_height{0}, m_depth{0};
 

--- a/vscode.tasks.json
+++ b/vscode.tasks.json
@@ -4,13 +4,13 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "CMake: Build",
+            "label": "Debug: CMake: Build",
             "type": "shell",
             "command": "cmake --build ${config:cmake.buildDirectory} --config Debug",
             "problemMatcher": []
         },
         {
-            "label": "Qt Deploy",
+            "label": "Debug: Qt Deploy",
             "type": "shell",
             "command": "D:\\Qt\\5.15.2\\msvc2019_64\\bin\\windeployqt.exe",
             "options": {
@@ -22,10 +22,50 @@
             "problemMatcher": []
         },
         {
-            "label": "Build and Deploy",
+            "label": "Debug: Build and Deploy",
             "dependsOn": [
-                "CMake: Build",
-                "Qt Deploy"
+                "Debug: CMake: Build",
+                "Debug: Qt Deploy"
+            ],
+            "dependsOrder": "sequence",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        },
+
+
+        {
+            "label": "Release: CMake: Build",
+            "type": "shell",
+            "command": "cmake --build ${config:cmake.buildDirectory} --config Release",
+            "problemMatcher": []
+        },
+        {
+            "label": "Release: Qt Deploy",
+            "type": "shell",
+            "command": "D:\\Qt\\5.15.2\\msvc2019_64\\bin\\windeployqt.exe",
+            "options": {
+                "cwd": "${workspaceFolder}/build"
+            },
+            "args": [
+                "Release/megatron3000.exe"
+            ],
+            "problemMatcher": []
+        },
+        {
+            "label": "Release: Run",
+            "type": "shell",
+            "command": "${config:cmake.buildDirectory}/Release/megatron3000.exe",
+            "problemMatcher": []
+        },
+        {
+            "label": "Release: Build, Deploy and Run",
+            "dependsOn": [
+                "Release: CMake: Build",
+                "Release: Qt Deploy",
+                "Release: Run"
             ],
             "dependsOrder": "sequence",
             "group": {


### PR DESCRIPTION
Just a bunch of "smaller" tweaks and fixes.
 - Made datawidget a popup window that opens on *File* -> *Open* button (also `ctrl + o`). Fixes #18 .
 - Made it such that different renderers can load their different volumes and switch back to global volume. Closes #17 .
 - Fixed a bug with incorrect error states if failing to load data.
 - Reflected changes from #26 in viewport2d.
 - Added more debugging info