### PR TITLE
Volume slicing

### DIFF
--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -48,6 +48,7 @@ void Renderer::initializeGL() {
 
     mScreenVAO = std::make_unique<ScreenSpacedBuffer>();
     mAxisGlyph = std::make_unique<AxisGlyph>();
+    mPlane = std::make_unique<WorldPlaneGlyph>();
 
     glClearColor(0.f, 0.3f, 0.3f, 1.f);
 

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -152,9 +152,10 @@ void Renderer::zoom(double z)
 
     auto volume = getVolume();
     if (volume && mIsSlicePlaneEnabled && mIsCameraLinkedToSlicePlane) {
+        auto& plane = volume->m_slicingGeometry;
         const auto relativeTrans = mViewMatrixInverse * origMat;
-        const auto newPos = (relativeTrans * QVector4D{volume->m_slicingGeometry.pos, 1.f}).toVector3D();
-        volume->m_slicingGeometry.pos = newPos;
+        const auto newPos = (relativeTrans * QVector4D{plane.pos, 1.f}).toVector3D();
+        plane.pos = QVector3D::dotProduct(newPos, plane.dir) * plane.dir;
         volume->updateSlicingGeometryBuffer();
     }
 }

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -127,11 +127,17 @@ Renderer::~Renderer() {}
 
 void Renderer::zoom(double z)
 {
-    QMatrix4x4 pos = mPrivateViewMatrix;
 #ifndef NDEBUG
+    QMatrix4x4 pos = mPrivateViewMatrix;
     qDebug() << pos;
 #endif
     mPrivateViewMatrix(2,3) += z/2;
+
+    auto volume = getVolume();
+    if (volume && mIsSlicePlaneEnabled && mIsCameraLinkedToSlicePlane) {
+        const auto& dir = QVector3D{mPrivateViewMatrix * QVector4D{0.f, 0.f, 1.f, 0.f}};
+        volume->m_slicingGeometry.pos += dir * (z / 2);
+    }
 }
 
 
@@ -142,7 +148,19 @@ void Renderer::rotate(float dx, float dy)
     QMatrix4x4 inversePrivateView = mPrivateViewMatrix.inverted();
     QVector4D transformedAxis = inversePrivateView*QVector4D(rotVec,0.f);
 
-    mPrivateViewMatrix.rotate(0.5f*rotVec.length(),transformedAxis.toVector3D());
+    const auto rotation = QQuaternion::fromAxisAndAngle(transformedAxis.toVector3D(), 0.5f*rotVec.length());
+    mPrivateViewMatrix.rotate(rotation);
+
+    // Rotate plane:
+    auto volume = getVolume();
+    if (volume && mIsSlicePlaneEnabled && mIsCameraLinkedToSlicePlane) {
+        // const auto model = volume->m_slicingGeometry.model();
+        // const auto& newView = mPrivateViewMatrix.inverted();
+        // const auto& a = inversePrivateView * QVector4D{0.f, 0.f, 1.f, 0.f};
+        // const auto& b = newView * QVector4D{0.f, 0.f, 1.f, 0.f};
+        // const auto rotation = QQuaternion::rotationTo(a.toVector3D(), b.toVector3D());
+        volume->m_slicingGeometry.dir = (mPrivateViewMatrix.inverted() * QVector4D{0.f, 0.f, 1.f, 0.f}).toVector3D();
+    }
 }
 
 Shader& Renderer::shaderProgram(const std::string& name) {

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -12,6 +12,7 @@ class Volume;
 class ScreenSpacedBuffer;
 class AxisGlyph;
 class Shader;
+class WorldPlaneGlyph;
 
 class Renderer : public QOpenGLWidget, protected QOpenGLFunctions_4_5_Core
 {
@@ -30,7 +31,7 @@ public:
     bool mUseGlobalVolume{true};
     std::shared_ptr<Volume> mPrivateVolume;
 
-    ~Renderer();
+    ~Renderer() override;
 
     virtual void zoom(double z);
     void rotate(float dx, float dy);
@@ -53,6 +54,7 @@ protected:
     // Screen Spaced vertex array
     std::unique_ptr<ScreenSpacedBuffer> mScreenVAO;
     std::unique_ptr<AxisGlyph> mAxisGlyph;
+    std::unique_ptr<WorldPlaneGlyph> mPlane;
 
     QMatrix4x4 mPerspectiveMatrix;
 

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -35,7 +35,7 @@ public:
     bool mIsCameraLinkedToSlicePlane{false};
 
     std::unique_ptr<WorldPlaneGlyph> mPlane;
-    
+
     ~Renderer() override;
 
     virtual void zoom(double z);
@@ -45,6 +45,9 @@ public:
     virtual std::shared_ptr<Volume> getVolume() const;
     virtual QMatrix4x4& getViewMatrix(); 
     virtual std::shared_ptr<Volume> getVolume();
+
+    void viewMatrixUpdated();
+
 protected:
     void initializeGL() override;
     void paintGL() override;
@@ -52,8 +55,6 @@ protected:
 
     // Helper function to render an axis on screen
     void drawAxis();
-
-    void viewMatrixUpdated();
 
 
     MainWindow* mMainWindow;

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -51,6 +51,8 @@ protected:
     // Helper function to render an axis on screen
     void drawAxis();
 
+    void viewMatrixUpdated();
+
 
     MainWindow* mMainWindow;
 
@@ -60,6 +62,10 @@ protected:
     std::unique_ptr<WorldPlaneGlyph> mPlane;
 
     QMatrix4x4 mPerspectiveMatrix;
+
+    // Cached inverse of perspective and MVP matrix for better performance
+    QMatrix4x4 mViewMatrixInverse;
+    QMatrix4x4 mMVPInverse;
 
     QElapsedTimer mFrameTimer, mAliveTimer;
     uint32_t mFrameCount{0};

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -34,6 +34,8 @@ public:
     bool mIsSlicePlaneEnabled{false};
     bool mIsCameraLinkedToSlicePlane{false};
 
+    std::unique_ptr<WorldPlaneGlyph> mPlane;
+    
     ~Renderer() override;
 
     virtual void zoom(double z);
@@ -59,7 +61,6 @@ protected:
     // Screen Spaced vertex array
     std::unique_ptr<ScreenSpacedBuffer> mScreenVAO;
     std::unique_ptr<AxisGlyph> mAxisGlyph;
-    std::unique_ptr<WorldPlaneGlyph> mPlane;
 
     QMatrix4x4 mPerspectiveMatrix;
 

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -31,6 +31,9 @@ public:
     bool mUseGlobalVolume{true};
     std::shared_ptr<Volume> mPrivateVolume;
 
+    bool mIsSlicePlaneEnabled{false};
+    bool mIsCameraLinkedToSlicePlane{false};
+
     ~Renderer() override;
 
     virtual void zoom(double z);

--- a/src/renderer2d.cpp
+++ b/src/renderer2d.cpp
@@ -42,7 +42,6 @@ void Renderer2D::paintGL() {
     glClear(GL_COLOR_BUFFER_BIT);
 
     const auto& viewMatrix = getViewMatrix();
-    const auto MVP = (mPerspectiveMatrix * viewMatrix).inverted();
     const auto& volume = getVolume();
     Volume::Guard volumeGuard;
     const auto time = mFrameTimer.elapsed() * 0.001f;
@@ -53,7 +52,7 @@ void Renderer2D::paintGL() {
 #endif
 
     shader.bind();
-    shader.setUniformValue("MVP", MVP);
+    shader.setUniformValue("MVP", mMVPInverse);
     shader.setUniformValue("time", time);
     
     if (volume) {

--- a/src/renderer3d.cpp
+++ b/src/renderer3d.cpp
@@ -43,6 +43,7 @@ void Renderer3D::paintGL() {
     // mPrivateViewMatrix.rotate(10.0f * deltaTime, QVector3D{0.5f, 1.f, 0.f});
     const auto& viewMatrix = getViewMatrix();
     const auto MVP = (mPerspectiveMatrix * viewMatrix).inverted();
+    QMatrix4x4 planeModelMat;
     const auto& volume = getVolume();
     Volume::Guard volumeGuard;
 
@@ -51,6 +52,10 @@ void Renderer3D::paintGL() {
     if (!shader.isLinked()) return;
 #endif
     
+    if (volume) {
+        const auto viewUp = (viewMatrix.inverted() * QVector4D{0.f, 1.f, 0.f, 0.f}).toVector3D();
+        planeModelMat = volume->m_slicingGeometry.model(viewUp);
+    }
     /* I'm rendering one front-facing plane and one back-facing plane
      * in order to "simulate" the effect of a transparent two-sided
      * on both sides of the volume rendering. The first one takes
@@ -61,7 +66,7 @@ void Renderer3D::paintGL() {
     if (volume && mIsSlicePlaneEnabled) {
         glFrontFace(GL_CW); // Reverse winding order to reverse plane direction
         const auto& plane = volume->m_slicingGeometry;
-        mPlane->draw(MVP, plane.pos, plane.dir);
+        mPlane->draw(MVP, planeModelMat);
         glFrontFace(GL_CCW);
     }
 
@@ -88,7 +93,7 @@ void Renderer3D::paintGL() {
     // // Render front plane glyph
     // if (volume && mIsSlicePlaneEnabled) {
     //     const auto& plane = volume->m_slicingGeometry;
-    //     mPlane->draw(MVP, plane.pos, plane.dir);
+    //     mPlane->draw(MVP, planeModelMat);
     // }
 
     drawAxis();

--- a/src/renderer3d.cpp
+++ b/src/renderer3d.cpp
@@ -58,7 +58,7 @@ void Renderer3D::paintGL() {
      * care of volume -> plane blending.
      */
     // Render back plane glyph
-    if (volume) {
+    if (volume && mIsSlicePlaneEnabled) {
         glFrontFace(GL_CW); // Reverse winding order to reverse plane direction
         const auto& plane = volume->m_slicingGeometry;
         mPlane->draw(MVP, plane.pos, plane.dir);
@@ -71,7 +71,7 @@ void Renderer3D::paintGL() {
     if (volume) {
         shader.setUniformValue("volumeScale", volume->volumeScale());
         shader.setUniformValue("volumeSpacing", volume->volumeSpacing());
-        shader.setUniformValue("isSlicingEnabled", true);
+        shader.setUniformValue("isSlicingEnabled", mIsSlicePlaneEnabled);
         shader.setUniformValue("time", mAliveTimer.elapsed() * 0.001f);
 
         // Transform slicing plane and update buffer:
@@ -85,25 +85,15 @@ void Renderer3D::paintGL() {
     glDisable(GL_CULL_FACE);
     mScreenVAO->draw();
 
-    // Render front plane glyph
-    if (volume) {
-        const auto& plane = volume->m_slicingGeometry;
-        mPlane->draw(MVP, plane.pos, plane.dir);
-    }
+    // // Render front plane glyph
+    // if (volume && mIsSlicePlaneEnabled) {
+    //     const auto& plane = volume->m_slicingGeometry;
+    //     mPlane->draw(MVP, plane.pos, plane.dir);
+    // }
 
     drawAxis();
 
     ++mFrameCount;
-}
-
-Plane Renderer3D::transformSlicingGeometry(const QMatrix4x4& trans, const Plane& geometry) const {
-    auto tPos = trans * QVector4D{geometry.pos, 1.f};
-    tPos *= tPos.w();
-    auto tDir = trans * QVector4D{geometry.dir, 0.f};
-    tDir *= tDir.w();
-    tDir.normalize();
-
-    return {QVector3D{tPos}, QVector3D{tDir}};
 }
 
 Renderer3D::~Renderer3D() {};

--- a/src/renderer3d.cpp
+++ b/src/renderer3d.cpp
@@ -37,6 +37,8 @@ void Renderer3D::paintGL() {
     const float deltaTime = mFrameTimer.restart() * 0.001;
 
     glClear(GL_COLOR_BUFFER_BIT);
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
     // mPrivateViewMatrix.rotate(10.0f * deltaTime, QVector3D{0.5f, 1.f, 0.f});
     const auto& viewMatrix = getViewMatrix();
@@ -49,6 +51,9 @@ void Renderer3D::paintGL() {
     if (!shader.isLinked()) return;
 #endif
 
+    // Render plane glyph
+    mPlane->draw(MVP, {2.f, 0.f, 0.f}, QVector3D{-1.f, 0.f, 1.f}.normalized());
+
     shader.bind();
     shader.setUniformValue("MVP", MVP);
     
@@ -56,6 +61,7 @@ void Renderer3D::paintGL() {
         shader.setUniformValue("volumeScale", volume->volumeScale());
         shader.setUniformValue("volumeSpacing", volume->volumeSpacing());
         shader.setUniformValue("isSlicingEnabled", true);
+        shader.setUniformValue("time", mAliveTimer.elapsed() * 0.001f);
 
         // Transform slicing plane and update buffer:
         // auto slicingGeometry = transformSlicingGeometry(MVP, volume->m_slicingGeometry);
@@ -65,7 +71,7 @@ void Renderer3D::paintGL() {
         volumeGuard = volume->guard();
     }
 
-    mScreenVAO->draw();
+    // mScreenVAO->draw();
 
     drawAxis();
 
@@ -81,3 +87,5 @@ Plane Renderer3D::transformSlicingGeometry(const QMatrix4x4& trans, const Plane&
 
     return {QVector3D{tPos}, QVector3D{tDir}};
 }
+
+Renderer3D::~Renderer3D() {};

--- a/src/renderer3d.h
+++ b/src/renderer3d.h
@@ -1,6 +1,10 @@
 #ifndef RENDERER3D_H
 #define RENDERER3D_H
 
+namespace Slicing {
+    struct Plane;
+}
+
 #include "renderer.h"
 
 class Renderer3D : public Renderer {
@@ -10,6 +14,8 @@ public:
 protected:
     void initializeGL() override;
     void paintGL() override;
+
+    Slicing::Plane transformSlicingGeometry(const QMatrix4x4& trans, const Slicing::Plane& geometry) const;
 };
 
 #endif // RENDERER3D_H

--- a/src/renderer3d.h
+++ b/src/renderer3d.h
@@ -6,10 +6,12 @@ namespace Slicing {
 }
 
 #include "renderer.h"
+#include <memory>
 
 class Renderer3D : public Renderer {
 public:
     Renderer3D(QWidget *parent = nullptr) : Renderer{parent} {}
+    ~Renderer3D() override;
 
 protected:
     void initializeGL() override;

--- a/src/renderer3d.h
+++ b/src/renderer3d.h
@@ -16,8 +16,6 @@ public:
 protected:
     void initializeGL() override;
     void paintGL() override;
-
-    Slicing::Plane transformSlicingGeometry(const QMatrix4x4& trans, const Slicing::Plane& geometry) const;
 };
 
 #endif // RENDERER3D_H

--- a/src/renderutils.cpp
+++ b/src/renderutils.cpp
@@ -277,8 +277,13 @@ void WorldPlaneGlyph::draw(const QMatrix4x4& MVP, QMatrix4x4 model) {
 
 void WorldPlaneGlyph::draw(const QMatrix4x4& MVP, const QVector3D& pos, const QVector3D& dir) {
     QMatrix4x4 model{MatIdentityValues};
-    const auto rot = QQuaternion::rotationTo({0.f, 0.f, -1.f}, dir).normalized();
-    model.rotate(rot);
+    model.rotate(QQuaternion::rotationTo(QVector3D{0.f, 0.f, -1.f}, dir));
+    model.translate(pos);
+    draw(MVP, model);
+}
+
+void WorldPlaneGlyph::draw(const QMatrix4x4& MVP, const QVector3D& pos, const QQuaternion& rot) {
+    auto model = QMatrix4x4{rot.toRotationMatrix()};
     model.translate(pos);
     draw(MVP, model);
 }

--- a/src/renderutils.cpp
+++ b/src/renderutils.cpp
@@ -213,13 +213,13 @@ WorldPlaneGlyph::WorldPlaneGlyph() {
 
     // Pos (x,y,z)
     const GLfloat vertices[] = {
-        -1.f, -1.f, 0.f,
-        1.f, -1.f, 0.f,
-        1.f, 1.f, 0.f,
+        -1.f, 0., -1.f,
+        1.f, 0.f, -1.f,
+        1.f, 0.f, 1.f,
 
-        -1.f, -1.f, 0.f,
-        1.f, 1.f, 0.f,
-        -1.f, 1.f, 0.f
+        -1.f, 0.f, -1.f,
+        1.f, 0.f, 1.f,
+        -1.f, 0.f, 1.f
     };
 
     glGenBuffers(1, &mVBO);
@@ -260,6 +260,7 @@ void WorldPlaneGlyph::unbind() {
 }
 
 void WorldPlaneGlyph::draw(const QMatrix4x4& MVP, QMatrix4x4 model) {
+    glEnable(GL_CULL_FACE);
     bind();
     const auto planeMat = MVP.inverted() * model;
     auto& shader = ShaderManager::get().shader("plane");
@@ -268,6 +269,7 @@ void WorldPlaneGlyph::draw(const QMatrix4x4& MVP, QMatrix4x4 model) {
 #endif
     shader.bind();
     shader.setUniformValue("MVP", planeMat);
+    shader.setUniformValue("alpha", std::clamp(mAlpha, 0.f, 1.f));
 
     glDrawArrays(GL_TRIANGLES, 0, 6);
     unbind();
@@ -275,7 +277,7 @@ void WorldPlaneGlyph::draw(const QMatrix4x4& MVP, QMatrix4x4 model) {
 
 void WorldPlaneGlyph::draw(const QMatrix4x4& MVP, const QVector3D& pos, const QVector3D& dir) {
     QMatrix4x4 model{MatIdentityValues};
-    const auto rot = QQuaternion::rotationTo({0.f, 0.f, 1.f}, dir).normalized();
+    const auto rot = QQuaternion::rotationTo({0.f, 0.f, -1.f}, dir).normalized();
     model.rotate(rot);
     model.translate(pos);
     draw(MVP, model);

--- a/src/renderutils.cpp
+++ b/src/renderutils.cpp
@@ -261,9 +261,12 @@ void WorldPlaneGlyph::draw(const QMatrix4x4& MVP, const QVector3D& up, const QVe
     glEnable(GL_CULL_FACE);
     bind();
 
+    // Reproject the position onto the direction to center it. (making positions orthogonal to dir = 0)
+    const QVector3D centeredPos = QVector3D::dotProduct(pos, dir) * dir;
+
     // Update buffer
     const GLfloat vals[] = {
-        pos.x(), pos.y(), pos.z(),
+        centeredPos.x(), centeredPos.y(), centeredPos.z(),
         dir.x(), dir.y(), dir.z()
     };
     glBindBuffer(GL_ARRAY_BUFFER, mVBO);

--- a/src/renderutils.cpp
+++ b/src/renderutils.cpp
@@ -262,7 +262,7 @@ void WorldPlaneGlyph::unbind() {
 void WorldPlaneGlyph::draw(const QMatrix4x4& MVP, const QMatrix4x4& model) {
     glEnable(GL_CULL_FACE);
     bind();
-    const auto planeMat = MVP.inverted() * model;
+    const auto planeMat = MVP * model;
     auto& shader = ShaderManager::get().shader("plane");
 #ifndef NDEBUG
     if (!shader.isLinked()) return;

--- a/src/renderutils.cpp
+++ b/src/renderutils.cpp
@@ -213,13 +213,13 @@ WorldPlaneGlyph::WorldPlaneGlyph() {
 
     // Pos (x,y,z)
     const GLfloat vertices[] = {
-        -1.f, 0., -1.f,
-        1.f, 0.f, -1.f,
-        1.f, 0.f, 1.f,
+        -1.f, -1.f, 0.f,
+        1.f, -1.f, 0.f,
+        1.f, 1.f, 0.f,
 
-        -1.f, 0.f, -1.f,
-        1.f, 0.f, 1.f,
-        -1.f, 0.f, 1.f
+        -1.f, -1.f, 0.f,
+        1.f, 1.f, 0.f,
+        -1.f, 1.f, 0.f
     };
 
     glGenBuffers(1, &mVBO);
@@ -259,7 +259,7 @@ void WorldPlaneGlyph::unbind() {
     glBindVertexArray(0);
 }
 
-void WorldPlaneGlyph::draw(const QMatrix4x4& MVP, QMatrix4x4 model) {
+void WorldPlaneGlyph::draw(const QMatrix4x4& MVP, const QMatrix4x4& model) {
     glEnable(GL_CULL_FACE);
     bind();
     const auto planeMat = MVP.inverted() * model;
@@ -277,8 +277,9 @@ void WorldPlaneGlyph::draw(const QMatrix4x4& MVP, QMatrix4x4 model) {
 
 void WorldPlaneGlyph::draw(const QMatrix4x4& MVP, const QVector3D& pos, const QVector3D& dir) {
     QMatrix4x4 model{MatIdentityValues};
-    model.rotate(QQuaternion::rotationTo(QVector3D{0.f, 0.f, -1.f}, dir));
-    model.translate(pos);
+    model.lookAt(pos, pos + dir, (MVP * QVector4D{0.f, 1.f, 0.f, 0.f}).toVector3D());
+    // model.rotate(QQuaternion::rotationTo(QVector3D{0.f, 0.f, -1.f}, dir));
+    // model.translate(pos);
     draw(MVP, model);
 }
 

--- a/src/renderutils.h
+++ b/src/renderutils.h
@@ -70,6 +70,8 @@ public:
     void bind();
     void unbind();
 
+    GLfloat mAlpha = 0.2f;
+
     void draw(const QMatrix4x4& MVP, QMatrix4x4 model = QMatrix4x4{MatIdentityValues});
     void draw(const QMatrix4x4& MVP, const QVector3D& pos, const QVector3D& dir);
 

--- a/src/renderutils.h
+++ b/src/renderutils.h
@@ -72,9 +72,8 @@ public:
 
     GLfloat mAlpha = 0.2f;
 
-    void draw(const QMatrix4x4& MVP, const QMatrix4x4& model = QMatrix4x4{MatIdentityValues});
-    void draw(const QMatrix4x4& MVP, const QVector3D& pos, const QVector3D& dir);
-    void draw(const QMatrix4x4& MVP, const QVector3D& pos, const QQuaternion& rot);
+    void draw(const QMatrix4x4& MVP = QMatrix4x4{MatIdentityValues}, const QVector3D& up = {0.f, 1.f, 0.f},
+              const QVector3D& pos = {0.f, 0.f, 0.f}, const QVector3D& dir = {0.f, 0.f, -1.f});
 
     WorldPlaneGlyph();
     ~WorldPlaneGlyph();

--- a/src/renderutils.h
+++ b/src/renderutils.h
@@ -70,7 +70,7 @@ public:
     void bind();
     void unbind();
 
-    GLfloat mAlpha = 0.2f;
+    GLfloat mAlpha = 0.05f;
 
     void draw(const QMatrix4x4& MVP = QMatrix4x4{MatIdentityValues}, const QVector3D& up = {0.f, 1.f, 0.f},
               const QVector3D& pos = {0.f, 0.f, 0.f}, const QVector3D& dir = {0.f, 0.f, -1.f});

--- a/src/renderutils.h
+++ b/src/renderutils.h
@@ -3,6 +3,7 @@
 
 #include <QOpenGLFunctions_4_5_Core>
 #include <QVector2D>
+#include <QMatrix4x4>
 
 /**
  * @brief Helper class to draw a screen spaced quad
@@ -58,6 +59,23 @@ public:
     ~NodeGlyphs();
 };
 
+
+constexpr float MatIdentityValues[] = {1.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f};
+
+class WorldPlaneGlyph : protected QOpenGLFunctions_4_5_Core {
+private:
+    GLuint mVAO, mVBO;
+
+public:
+    void bind();
+    void unbind();
+
+    void draw(const QMatrix4x4& MVP, QMatrix4x4 model = QMatrix4x4{MatIdentityValues});
+    void draw(const QMatrix4x4& MVP, const QVector3D& pos, const QVector3D& dir);
+
+    WorldPlaneGlyph();
+    ~WorldPlaneGlyph();
+};
 
 
 

--- a/src/renderutils.h
+++ b/src/renderutils.h
@@ -72,7 +72,7 @@ public:
 
     GLfloat mAlpha = 0.2f;
 
-    void draw(const QMatrix4x4& MVP, QMatrix4x4 model = QMatrix4x4{MatIdentityValues});
+    void draw(const QMatrix4x4& MVP, const QMatrix4x4& model = QMatrix4x4{MatIdentityValues});
     void draw(const QMatrix4x4& MVP, const QVector3D& pos, const QVector3D& dir);
     void draw(const QMatrix4x4& MVP, const QVector3D& pos, const QQuaternion& rot);
 

--- a/src/renderutils.h
+++ b/src/renderutils.h
@@ -74,6 +74,7 @@ public:
 
     void draw(const QMatrix4x4& MVP, QMatrix4x4 model = QMatrix4x4{MatIdentityValues});
     void draw(const QMatrix4x4& MVP, const QVector3D& pos, const QVector3D& dir);
+    void draw(const QMatrix4x4& MVP, const QVector3D& pos, const QQuaternion& rot);
 
     WorldPlaneGlyph();
     ~WorldPlaneGlyph();

--- a/src/shaders/plane.fs
+++ b/src/shaders/plane.fs
@@ -1,0 +1,7 @@
+#version 450
+
+out vec4 fragColor;
+
+void main() {
+    fragColor = vec4(1., 0., 0., 1.);
+}

--- a/src/shaders/plane.fs
+++ b/src/shaders/plane.fs
@@ -5,5 +5,5 @@ uniform float alpha;
 out vec4 fragColor;
 
 void main() {
-    fragColor = vec4(0., 1., 0., alpha);
+    fragColor = vec4(1., 0., 0., alpha);
 }

--- a/src/shaders/plane.fs
+++ b/src/shaders/plane.fs
@@ -1,7 +1,9 @@
 #version 450
 
+uniform float alpha;
+
 out vec4 fragColor;
 
 void main() {
-    fragColor = vec4(1., 0., 0., 1.);
+    fragColor = vec4(0., 1., 0., alpha);
 }

--- a/src/shaders/plane.gs
+++ b/src/shaders/plane.gs
@@ -1,0 +1,25 @@
+#version 450
+
+layout(points) in;
+layout(triangle_strip, max_vertices = 4) out;
+
+flat in vec3 dir[];
+
+uniform mat4 MVP;
+uniform vec3 up = vec3(0., 1., 0.);
+
+void main() {
+    const float size = 2.0;
+    const vec3 right = normalize(cross(dir[0], up));
+    const vec3 up2 = normalize(cross(right, dir[0]));
+    
+    gl_Position = gl_in[0].gl_Position + MVP * vec4(size * (right + up2), 0.);
+    EmitVertex();
+    gl_Position = gl_in[0].gl_Position + MVP * vec4(size * (-right + up2), 0.);
+    EmitVertex();
+    gl_Position = gl_in[0].gl_Position + MVP * vec4(size * (right - up2), 0.);
+    EmitVertex();
+    gl_Position = gl_in[0].gl_Position + MVP * vec4(size * (-right - up2), 0.);
+    EmitVertex();
+    EndPrimitive();
+}

--- a/src/shaders/plane.vs
+++ b/src/shaders/plane.vs
@@ -1,0 +1,9 @@
+#version 450
+
+layout(location = 0) in vec3 inPos;
+
+uniform mat4 MVP;
+
+void main() {
+    gl_Position = MVP * vec4(inPos, 1.0);
+}

--- a/src/shaders/plane.vs
+++ b/src/shaders/plane.vs
@@ -1,9 +1,13 @@
 #version 450
 
 layout(location = 0) in vec3 inPos;
+layout(location = 1) in vec3 inDir;
 
 uniform mat4 MVP;
 
+flat out vec3 dir;
+
 void main() {
+    dir = inDir;
     gl_Position = MVP * vec4(inPos, 1.0);
 }

--- a/src/shaders/volume.fs
+++ b/src/shaders/volume.fs
@@ -11,6 +11,7 @@ layout(binding = 1) uniform sampler1D transferFunction;
 uniform vec3 volumeScale;
 uniform vec3 volumeSpacing;
 uniform bool isSlicingEnabled = false;
+uniform float time = 0.0;
 
 // I like to define a plane as a direction and a point in the plane.
 struct Plane
@@ -104,7 +105,7 @@ void main() {
             vec4 tex = tf(p);
             float density = tex.a;
             vec3 g = gradient(p);
-            density *= length(g) * 100.0;
+            density *= length(g) * 10.0;
             vec3 normal = normalize(g);
             vec3 color = tex.rgb;
             vec3 phong = max(dot(normal, vec3(1.0, 0., 0.)), 0.15) * color;
@@ -118,7 +119,5 @@ void main() {
             depth += stepSize;
         }
     }
-
-    if (fragColor.a < 0.8)
-        fragColor = vec4(abs(rayDir), 1.);
+    // fragColor = vec4(fragColor.rgb * fragColor.a + (1.0 - fragColor.a) * abs(rayDir), 1.0);
 }

--- a/src/transferfunctionrenderer.cpp
+++ b/src/transferfunctionrenderer.cpp
@@ -235,17 +235,21 @@ void TransferFunctionRenderer::updateVolume() {
 
     bool bUpper = false;
     for (const auto& [sum, num] : valueBuckets) {
+        QVector4D val{};
         if (num != 0) {
             // Fill middle values with buckets
-            values.push_back(sum / num);
+            val = sum / num;
             bUpper = true;
         } else {
             // Fill upper values with last node:
             if (bUpper)
-                values.push_back(QVector4D{colors.back(), sortedPoints.back().pos.y()});
+                val = QVector4D{colors.back(), sortedPoints.back().pos.y()};
             else
-                values.push_back(QVector4D{colors.front(), sortedPoints.front().pos.y()});
+                val = QVector4D{colors.front(), sortedPoints.front().pos.y()};
         }
+        // [-1, 1] -> [0, 1]
+        val.setY(val.y() * 0.5f + 0.5f);
+        values.push_back(val);
     }
 
     volume->updateTransferFunction(values);

--- a/src/viewport2d.cpp
+++ b/src/viewport2d.cpp
@@ -154,11 +154,24 @@ void Viewport2D::setAxis(QAction* axis) {
                         viewMat.rotate(-90.f, {1.f, 0.f, 0.f});
                     
                     viewMat.translate(0.f, 0.f, zoom);
+                    mRenderer->viewMatrixUpdated();
                 }
             }
             break;
         case AxisMode::ARBITRARY:
+            break;
         case AxisMode::SLICE:
+            {
+                const auto& volume = mRenderer->getVolume();
+                if (volume) {
+                    const auto& plane = volume->m_slicingGeometry;
+                    auto& viewMat = mRenderer->getViewMatrix();
+                    viewMat.lookAt(plane.pos, plane.pos + plane.dir, {0.f, 1.f, 0.f});
+                    mRenderer->viewMatrixUpdated();
+                }
+            }
             break;
     }
+
+    mRenderer->mIsSlicePlaneEnabled = mRenderer->mIsCameraLinkedToSlicePlane = mAxisMode == AxisMode::SLICE;
 }

--- a/src/viewport3d.cpp
+++ b/src/viewport3d.cpp
@@ -15,17 +15,33 @@ Viewport3D::Viewport3D(QWidget *parent) :
     // Menubar:
     auto datamenu = mMenuBar->addMenu("Data");
     auto openAction = datamenu->addAction("Open");
-    connect(openAction, &QAction::triggered, this, &Viewport3D::load);
     mRemoveVolumeAction = datamenu->addAction("Use global volume");
     mRemoveVolumeAction->setCheckable(true);
     mRemoveVolumeAction->setChecked(true);
-    connect(mRemoveVolumeAction, &QAction::triggered, this, &Viewport3D::removeVolume);
-    
+
+    // Slice menu
+    auto slicemenu = mMenuBar->addMenu("Slicing");
+    auto sliceEnable = slicemenu->addAction("Enable");
+    sliceEnable->setCheckable(true);
+    auto sliceMove = slicemenu->addAction("Linked to camera");
+    sliceMove->setCheckable(true);
+
     mLayout->addWidget(mMenuBar);
 
     // OpenGL Render Widget:
     mRenderer = new Renderer3D{this};
     mLayout->addWidget(mRenderer);
+
+    // Connections:
+    connect(openAction, &QAction::triggered, this, &Viewport3D::load);
+    connect(mRemoveVolumeAction, &QAction::triggered, this, &Viewport3D::removeVolume);
+    connect(sliceEnable, &QAction::toggled, this, [&](bool bEnabled){
+        mRenderer->mIsSlicePlaneEnabled = bEnabled;
+    });
+    connect(sliceMove, &QAction::toggled, this, [&](bool bEnabled){
+        mRenderer->mIsCameraLinkedToSlicePlane = bEnabled;
+    });
+
 
     setLayout(mLayout);
 }

--- a/src/viewport3d.cpp
+++ b/src/viewport3d.cpp
@@ -4,6 +4,10 @@
 #include "mainwindow.h"
 #include "volume.h"
 #include "datawidget.h"
+#include <QWidgetAction>
+#include <QSlider>
+#include <QLabel>
+#include "renderutils.h"
 
 Viewport3D::Viewport3D(QWidget *parent) :
     QWidget{parent}, IMenu{this}
@@ -26,6 +30,20 @@ Viewport3D::Viewport3D(QWidget *parent) :
     mSliceMoveToggle = slicemenu->addAction("Linked to camera");
     mSliceMoveToggle->setCheckable(true);
 
+    // Opacity slider menu widget:
+    auto sliceSlider = new QWidgetAction{this};
+    auto sliderWidgetWrapper = new QWidget{};
+    auto sliderLayout = new QVBoxLayout{};
+    sliderLayout->addWidget(new QLabel{"Plane opacity:"});
+    auto slider = new QSlider{Qt::Horizontal};
+    slider->setMinimum(0);
+    slider->setMaximum(100);
+    slider->setValue(5);
+    sliderLayout->addWidget(slider);
+    sliderWidgetWrapper->setLayout(sliderLayout);
+    sliceSlider->setDefaultWidget(sliderWidgetWrapper);
+    slicemenu->addAction(sliceSlider);
+
     mLayout->addWidget(mMenuBar);
 
     // OpenGL Render Widget:
@@ -40,6 +58,10 @@ Viewport3D::Viewport3D(QWidget *parent) :
     });
     connect(mSliceMoveToggle, &QAction::toggled, this, [&](bool bEnabled){
         mRenderer->mIsCameraLinkedToSlicePlane = bEnabled;
+    });
+    connect(slider, &QAbstractSlider::valueChanged, this, [&](int value){
+        const auto percentage = value * 0.01f;
+        mRenderer->mPlane->mAlpha = percentage;
     });
 
 

--- a/src/viewport3d.cpp
+++ b/src/viewport3d.cpp
@@ -23,8 +23,8 @@ Viewport3D::Viewport3D(QWidget *parent) :
     auto slicemenu = mMenuBar->addMenu("Slicing");
     auto sliceEnable = slicemenu->addAction("Enable");
     sliceEnable->setCheckable(true);
-    auto sliceMove = slicemenu->addAction("Linked to camera");
-    sliceMove->setCheckable(true);
+    mSliceMoveToggle = slicemenu->addAction("Linked to camera");
+    mSliceMoveToggle->setCheckable(true);
 
     mLayout->addWidget(mMenuBar);
 
@@ -38,7 +38,7 @@ Viewport3D::Viewport3D(QWidget *parent) :
     connect(sliceEnable, &QAction::toggled, this, [&](bool bEnabled){
         mRenderer->mIsSlicePlaneEnabled = bEnabled;
     });
-    connect(sliceMove, &QAction::toggled, this, [&](bool bEnabled){
+    connect(mSliceMoveToggle, &QAction::toggled, this, [&](bool bEnabled){
         mRenderer->mIsCameraLinkedToSlicePlane = bEnabled;
     });
 
@@ -63,9 +63,20 @@ void Viewport3D::mousePressEvent(QMouseEvent *ev)
     qDebug() << "Clicked in 3D viewport area";
 #endif
 
+    if (ev->button() == Qt::MouseButton::RightButton)
+        if (mRenderer && mRenderer->mIsSlicePlaneEnabled && !mRenderer->mIsCameraLinkedToSlicePlane)
+            mSliceMoveToggle->toggle();
+
     lastPoint3D = QPoint(ev->pos().x(),ev->pos().y());
 
     emit Mouse_pressed3D();
+}
+
+void Viewport3D::mouseReleaseEvent(QMouseEvent *ev)
+{
+    if (ev->button() == Qt::MouseButton::RightButton)
+        if (mRenderer && mRenderer->mIsSlicePlaneEnabled && mRenderer->mIsCameraLinkedToSlicePlane)
+            mSliceMoveToggle->toggle();
 }
 
 void Viewport3D::wheelEvent(QWheelEvent *ev)

--- a/src/viewport3d.h
+++ b/src/viewport3d.h
@@ -17,9 +17,10 @@ class Viewport3D : public QWidget, public IMenu
 public:
     explicit Viewport3D(QWidget *parent = nullptr);
     ~Viewport3D();
-    void mouseMoveEvent(QMouseEvent *ev);
-    void mousePressEvent(QMouseEvent *ev);
-    void wheelEvent(QWheelEvent *ev);
+    void mouseMoveEvent(QMouseEvent *ev) override;
+    void mousePressEvent(QMouseEvent *ev) override;
+    void mouseReleaseEvent(QMouseEvent *ev) override;
+    void wheelEvent(QWheelEvent *ev) override;
 
 signals:
     void Mouse_pressed3D();
@@ -31,6 +32,7 @@ private:
     QVBoxLayout* mLayout{nullptr};
     QPoint lastPoint3D;
     QAction* mRemoveVolumeAction{nullptr};
+    QAction* mSliceMoveToggle{nullptr};
 
 private slots:
     void load();

--- a/src/volume.cpp
+++ b/src/volume.cpp
@@ -6,8 +6,15 @@
 #include <algorithm>
 #include "mini/ini.h"
 #include <QVector4D>
+#include <QMatrix4x4>
 
 using namespace Slicing;
+
+QMatrix4x4 Plane::model(const QVector3D& up) const {
+    QMatrix4x4 m;
+    m.lookAt(pos, pos + dir, up);
+    return m;
+}
 
 bool Volume::loadData(const QString &fileName)
 {

--- a/src/volume.cpp
+++ b/src/volume.cpp
@@ -10,9 +10,18 @@
 
 using namespace Slicing;
 
-QMatrix4x4 Plane::model(const QVector3D& up) const {
-    QMatrix4x4 m;
-    m.lookAt(pos, pos + dir, up);
+QMatrix4x4 Plane::model(QVector3D up) const {
+    // Look-at rotation:
+    const auto right = QVector3D::crossProduct(dir, up).normalized();
+    up = QVector3D::crossProduct(right, dir).normalized();
+    const float matVals[] = {
+        right.x(), up.x(), dir.x(), 0.f,
+        right.y(), up.y(), dir.y(), 0.f,
+        right.z(), up.z(), dir.z(), 0.f,
+        0.f, 0.f, 0.f, 1.f
+    };
+    QMatrix4x4 m{matVals};
+    m.translate(pos);
     return m;
 }
 

--- a/src/volume.cpp
+++ b/src/volume.cpp
@@ -238,8 +238,6 @@ void Volume::updateSlicingGeometryBuffer(const Plane& geometry) {
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
 }
 
-void applyGeometryTransformation(const QMatrix4x4& trans);
-
 Volume::~Volume() {
     if (m_texInitiated)
         glDeleteTextures(1, &m_texBuffer);

--- a/src/volume.h
+++ b/src/volume.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <QVector3D>
 #include <QQuaternion>
+#include <QMatrix3x3>
 
 namespace Slicing {
     // I like to define a plane as a direction and a point in the plane.
@@ -13,7 +14,8 @@ namespace Slicing {
         QVector3D pos{0.f, 0.f, 0.f};
         QVector3D dir{0.f, 0.f, -1.f};
 
-        QMatrix4x4 model(QVector3D up) const;
+        QMatrix3x3 rot(QVector3D up) const;
+        QMatrix4x4 model(const QVector3D& up) const;
     };
 }
 

--- a/src/volume.h
+++ b/src/volume.h
@@ -5,12 +5,15 @@
 #include <optional>
 #include <vector>
 #include <QVector3D>
+#include <QQuaternion>
 
 namespace Slicing {
     // I like to define a plane as a direction and a point in the plane.
     struct Plane {
         QVector3D pos{0.f, 0.f, 0.f};
         QVector3D dir{0.f, 0.f, -1.f};
+
+        QMatrix4x4 model(const QVector3D& up) const;
     };
 }
 

--- a/src/volume.h
+++ b/src/volume.h
@@ -13,7 +13,7 @@ namespace Slicing {
         QVector3D pos{0.f, 0.f, 0.f};
         QVector3D dir{0.f, 0.f, -1.f};
 
-        QMatrix4x4 model(const QVector3D& up) const;
+        QMatrix4x4 model(QVector3D up) const;
     };
 }
 


### PR DESCRIPTION
This pr adds a slicing plane that will cut through the volume renderer, exposing interior parts. The plane can be moved by pressing the "link to camera" button, or holding right click, which will make the plane move with the camera.

The plane is rendered as a separate glyph that will blend it's colors with the volume. The opacity of the blending can be changed from the menus. The plane is rendered as a view-aligned centered square.

This pr closes #25.