### PR TITLE
Async data loading

### DIFF
--- a/src/datawidget.h
+++ b/src/datawidget.h
@@ -2,6 +2,8 @@
 #define DATAWIDGET_H
 
 #include <QWidget>
+#include "runners.h"
+#include <QFutureWatcher>
 
 class Volume;
 class QFileSystemModel;
@@ -28,10 +30,19 @@ private slots:
 
     void on_listView_doubleClicked(const QModelIndex &index);
 
+    void finishLoading();
+
 private:
     Ui::DataWidget *ui;
     QFileSystemModel *dirmodel;
     QFileSystemModel *filemodel;
+
+    std::unique_ptr<QOpenGLContext> mThreadContext;
+    std::unique_ptr<QOffscreenSurface> mThreadSurface;
+
+    std::unique_ptr<DataReaderRunner> mRunner;
+    DataReaderRunner::FType mFuture;
+    QFutureWatcher<DataReaderRunner::RetType> mWatcher;
 
     void load(const QString& filePath);
 

--- a/src/datawidget.h
+++ b/src/datawidget.h
@@ -24,6 +24,7 @@ public:
 
 signals:
     void loaded(std::shared_ptr<Volume> volume, const std::string& identifier = {});
+    void finished();
 
 private slots:
     void on_treeView_clicked(const QModelIndex &index);
@@ -32,10 +33,16 @@ private slots:
 
     void finishLoading();
 
+protected:
+    void closeEvent(QCloseEvent* event) override;
+
 private:
     Ui::DataWidget *ui;
     QFileSystemModel *dirmodel;
     QFileSystemModel *filemodel;
+
+    // True when the widget has been closed during loading
+    bool mGlobalCancelled{false};
 
     std::unique_ptr<QOpenGLContext> mThreadContext;
     std::unique_ptr<QOffscreenSurface> mThreadSurface;

--- a/src/histogramwidget.cpp
+++ b/src/histogramwidget.cpp
@@ -63,7 +63,7 @@ HistogramWidget::HistogramWidget(QWidget *parent) :
                 throw std::logic_error{"Action not in list. >:("};
 #endif
             const auto index = sourceActionPos - mSourceOptionActions.begin();
-            mHistogramSource = static_cast<HistogramWidget::Source>(index);
+            mHistogramSource = static_cast<HistogramSource>(index);
             drawHistogram();
         });
     }
@@ -103,7 +103,7 @@ void HistogramWidget::drawHistogram()
     // Initialize async func:
 
     const auto tfValues = mMapToTransferFunction ? mVolume->transferFunctionValues() : std::vector<QVector4D>{};
-    const auto& cuttingPlane = mHistogramSource == Source::Plane ? mVolume->m_slicingGeometry : Slicing::Plane{};
+    const auto& cuttingPlane = mHistogramSource == HistogramSource::Plane ? mVolume->m_slicingGeometry : Slicing::Plane{};
 
     // Note to self: There's apparantly no easy way to pass gui objects between threads,
     // so can only really manipulate widgets with other threads.
@@ -208,7 +208,7 @@ Q_DECLARE_METATYPE( QFutureInterface<QVector<qreal>> );
 
 HistogramRunner::HistogramRunner(
     unsigned int binCount,
-    HistogramWidget::Source source,
+    HistogramSource source,
     std::shared_ptr<Volume> volume,
     std::vector<QVector4D> tfValues,
     const Slicing::Plane& plane)
@@ -263,7 +263,7 @@ void HistogramRunner::run() {
             return;
         }
 
-        if (mSource == HistogramWidget::Source::Plane) {
+        if (mSource == HistogramSource::Plane) {
             const auto box = mVolume->getVoxelBounds(mVolume->getVoxelIndex(i));
             if (!megamath::boxPlaneIntersect(box.pos, box.size, mPlane.pos, mPlane.dir))
                 continue;

--- a/src/histogramwidget.h
+++ b/src/histogramwidget.h
@@ -4,11 +4,10 @@
 #include <QWidget>
 #include "menuinterface.h"
 #include <QFutureWatcher>
-#include <QFuture>
-#include <QRunnable>
 #include <memory>
-#include <QFutureInterface>
 #include "volume.h"
+#include "runners.h"
+#include "renderutils.h"
 
 class QVBoxLayout;
 class MainWindow;
@@ -25,11 +24,6 @@ class HistogramWidget : public QWidget, public IMenu
     Q_OBJECT
 
 public:
-    enum class Source : uint8_t {
-        All = 0,
-        Plane
-    };
-
     explicit HistogramWidget(QWidget *parent = nullptr);
     ~HistogramWidget();
     std::shared_ptr<Volume> getVolume();
@@ -40,7 +34,7 @@ protected:
     unsigned int mBinCount = 30;
     void volumeSwitched() override final;
     void createView();
-    Source mHistogramSource;
+    HistogramSource mHistogramSource;
 
 private:
     QVBoxLayout* mLayout{nullptr};
@@ -55,45 +49,6 @@ private:
 
 private slots:
     void finishHistogramGeneration();
-};
-
-
-/**
- * @brief Helper class to wrap the histogram generation in a separate thread
- * This class is used by the global QThreadPool, which puts these runners in
- * a queue for them to wait their turn in order for a thread to become avilable
- * for them. When a thread is available, the HistogramRunners generates
- * a histogram, which after finished is inserted into the widget.
- * 
- * HistogramRunners can be cancelled mid-generation by setting mCancelled = true,
- * which will early return the connected future. 
- */
-class HistogramRunner : public QRunnable {
-public:
-    HistogramRunner(
-        unsigned int binCount = 256,
-        HistogramWidget::Source source = HistogramWidget::Source::All,
-        std::shared_ptr<Volume> volume = {},
-        std::vector<QVector4D> tfValues = {},
-        const Slicing::Plane& plane = {}
-    );
-    ~HistogramRunner() {}
-
-    void run() override;
-    QFuture<QVector<qreal>> future();
-
-    bool mCancelled{false};
-    const unsigned int mBinCount{30};
-    const HistogramWidget::Source mSource{HistogramWidget::Source::All};
-    std::unique_ptr<HistogramRunner> mPrevRunner;
-    QFuture<QVector<qreal>> mPrevFuture;
-    Slicing::Plane mPlane;
-
-private:
-    // https://stackoverflow.com/questions/59197694/qt-how-to-create-a-qfuture-from-a-thread
-    QFutureInterface<QVector<qreal>> mFutureInterface;
-    std::shared_ptr<Volume> mVolume;
-    std::vector<QVector4D> mTfValues;
 };
 
 #endif // HISTOGRAMWIDGET_H

--- a/src/renderutils.h
+++ b/src/renderutils.h
@@ -100,4 +100,9 @@ inline QVector2D aspectScale(float aspectRatio = 1.f) {
 
 QVector2D screenPointToNormalizedCoordinates(const QPoint& point, int width, int height);
 
+enum class HistogramSource : uint8_t {
+    All = 0,
+    Plane
+};
+
 #endif // RENDERUTILS_H

--- a/src/runners.h
+++ b/src/runners.h
@@ -1,0 +1,101 @@
+#ifndef RUNNERS_H
+#define RUNNERS_H
+
+/**
+ * @brief Helper worker classes (runners) for multithreading 
+ */
+
+#include <QRunnable>
+#include <QFuture>
+#include <QFutureWatcher>
+#include <memory>
+#include "volume.h"
+#include "renderutils.h"
+
+/**
+ * @brief Helper class to wrap the histogram generation in a separate thread
+ * This class is used by the global QThreadPool, which puts these runners in
+ * a queue for them to wait their turn in order for a thread to become avilable
+ * for them. When a thread is available, the HistogramRunners generates
+ * a histogram, which after finished is inserted into the widget.
+ * 
+ * HistogramRunners can be cancelled mid-generation by setting mCancelled = true,
+ * which will early return the connected future. 
+ */
+class HistogramRunner : public QRunnable {
+public:
+    using RetType = QVector<qreal>;
+    using FType = QFuture<QVector<qreal>>;
+
+    HistogramRunner(
+        unsigned int binCount = 256,
+        HistogramSource source = HistogramSource::All,
+        std::shared_ptr<Volume> volume = {},
+        std::vector<QVector4D> tfValues = {},
+        const Slicing::Plane& plane = {}
+    );
+    ~HistogramRunner() {}
+
+    void run() override;
+    QFuture<QVector<qreal>> future();
+
+    bool mCancelled{false};
+    const unsigned int mBinCount{30};
+    const HistogramSource mSource{HistogramSource::All};
+    std::unique_ptr<HistogramRunner> mPrevRunner;
+    QFuture<QVector<qreal>> mPrevFuture;
+    Slicing::Plane mPlane;
+
+private:
+    // https://stackoverflow.com/questions/59197694/qt-how-to-create-a-qfuture-from-a-thread
+    QFutureInterface<QVector<qreal>> mFutureInterface;
+    std::shared_ptr<Volume> mVolume;
+    std::vector<QVector4D> mTfValues;
+};
+
+
+
+
+
+class QOpenGLContext;
+class QOffscreenSurface;
+
+/**
+ * @brief Helper class to wrap data loading in a separate thread
+ * This class is used by the global QThreadPool, which puts these runners in
+ * a queue for them to wait their turn in order for a thread to become avilable
+ * for them.
+ * 
+ * DataReaderRunner can be cancelled mid-generation by setting mCancelled = true,
+ * which will early return the connected future. 
+ */
+class DataReaderRunner : public QRunnable {
+public:
+    using RetType = std::shared_ptr<Volume>;
+    using FType = QFuture<RetType>;
+
+    DataReaderRunner(
+        const QString& filePath,
+        QOpenGLContext* context,
+        QOffscreenSurface* surface
+    );
+    ~DataReaderRunner() {}
+
+
+    void run() override;
+    FType future();
+    const QString mPath;
+
+    bool mCancelled{false};
+    std::unique_ptr<DataReaderRunner> mPrevRunner;
+    FType mPrevFuture;
+
+private:
+    // https://stackoverflow.com/questions/59197694/qt-how-to-create-a-qfuture-from-a-thread
+    QFutureInterface<RetType> mFutureInterface;
+
+    QOpenGLContext* mContext{nullptr};
+    QOffscreenSurface* mSurface{nullptr};
+};
+
+#endif // RUNNERS_H

--- a/src/volume.h
+++ b/src/volume.h
@@ -1,5 +1,6 @@
 #ifndef VOLUME_H
 #define VOLUME_H
+
 #include <QObject>
 #include <QOpenGLFunctions_4_5_Core>
 #include <optional>
@@ -19,13 +20,16 @@ namespace Slicing {
     };
 }
 
+class QOpenGLContext;
+class QOffscreenSurface;
+
 class Volume : public QObject, protected QOpenGLFunctions_4_5_Core
 {
     Q_OBJECT
 public:
-    Volume() = default;
+    Volume(QOpenGLContext* context = nullptr, QOffscreenSurface* surface = nullptr);
 
-    bool loadData(const QString &fileName);
+    bool loadData(const QString &fileName, const bool& cancel = false);
 
     void bind(GLuint binding = 0, GLuint tfBinding = 1, GLuint geometryBinding = 4);
     void unbind();
@@ -93,6 +97,8 @@ private:
     bool m_slicingGeometryBufferInitiated{false};
     void generateSlicingGeometryBuffer();
 
+    QOpenGLContext* mContext{nullptr};
+    QOffscreenSurface* mSurface{nullptr};
 public:
     /**
      * @brief Helper class that binds the texture on construction and unbinds on destruction.


### PR DESCRIPTION
This PR enables the data loading widget to utilize other threads to load data in the background without freezing the application. This also simultaneously enables data loading to be cancelled by either opening another file before file is done loading, or by simply exiting the data loading window.