### PR TITLE
Slicing fixes and tweaks

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -14,6 +14,28 @@
 #include "histogramwidget.h"
 #include "transferfunctionwidget.h"
 
+DockWrapper::DockWrapper(const QString &title, QWidget *parent, Qt::WindowFlags flags)
+    : QDockWidget{title, parent, flags}
+{
+    setFocusPolicy(Qt::StrongFocus);
+}
+
+void DockWrapper::closeEvent(QCloseEvent* event) {
+    auto parent = dynamic_cast<MainWindow*>(parentWidget());
+    if (parent) {
+        auto& widgets = parent->mWidgets;
+        auto pos = std::find(widgets.begin(), widgets.end(), this);
+        if (pos != widgets.end())
+            widgets.erase(pos);
+    }
+    event->accept();
+}
+
+
+
+
+
+
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent),
     mUi{new Ui::MainWindow}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -25,16 +25,16 @@ MainWindow::MainWindow(QWidget *parent)
     // Connections:
     connect(mUi->action2D_Viewport, &QAction::triggered, this, [&](){
         // Lambda mediator: button connected to lambda -> lambda decides what widget to add to viewport
-        addWidget(createWrapperWidget(new Viewport2D{this}, "2D Viewport"));
+        addWidget(createWrappedWidget<Viewport2D>("2D Viewport"));
     });
     connect(mUi->action3D_Viewport, &QAction::triggered, this, [&](){
-        addWidget(createWrapperWidget(new Viewport3D{this}, "3D Viewport"));
+        addWidget(createWrappedWidget<Viewport3D>("3D Viewport"));
     });
     connect(mUi->actionTransfer_function, &QAction::triggered, this, [&](){
-        addWidget(createWrapperWidget(new TransferFunctionWidget{this}, "Transfer function"));
+        addWidget(createWrappedWidget<TransferFunctionWidget>("Transfer function"));
     });
     connect(mUi->actionHistogram_Widget, &QAction::triggered, this, [&](){
-        addWidget(createWrapperWidget(new HistogramWidget{this}, "Histogram Widget"));
+        addWidget(createWrappedWidget<HistogramWidget>("Histogram Widget"));
     });
     connect(mUi->actionOpen, &QAction::triggered, this, &MainWindow::load);
     connect(mUi->actionOpen_last_opened, &QAction::triggered, this, [=](){ load(true); });

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -11,15 +11,37 @@
 
 class QWidget;
 class Volume;
-class DockWrapper;
 class QShortcut;
 class DataWidget;
 class IMenu;
+
+
+
+/**
+ * @brief Wrapper helper class for QDockWidget
+ * 
+ */
+class DockWrapper : public QDockWidget {
+public:
+    explicit DockWrapper(
+        const QString &title,
+        QWidget *parent = nullptr,
+        Qt::WindowFlags flags = Qt::WindowFlags()
+    );
+
+protected:
+    void closeEvent(QCloseEvent* event) override;
+};
+
 
 QT_BEGIN_NAMESPACE
 namespace Ui { class MainWindow; }
 QT_END_NAMESPACE
 
+/**
+ * @brief Main application wrapper
+ * Handles all widgets, global shortcuts, and volumes.
+ */
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
@@ -79,35 +101,6 @@ private:
     void layoutDockWidget(DockWrapper* newWidget);
 
     std::vector<std::pair<std::string, std::shared_ptr<Volume>>> mVolumes;
-};
-
-
-
-
-
-/**
- * @brief Wrapper helper class for QDockWidget
- * 
- */
-class DockWrapper : public QDockWidget {
-public:
-    explicit DockWrapper(const QString &title, QWidget *parent = nullptr,
-                         Qt::WindowFlags flags = Qt::WindowFlags())
-        : QDockWidget{title, parent, flags} {
-            setFocusPolicy(Qt::StrongFocus);
-        }
-
-protected:
-    void closeEvent(QCloseEvent* event) override {
-        auto parent = dynamic_cast<MainWindow*>(parentWidget());
-        if (parent) {
-            auto& widgets = parent->mWidgets;
-            auto pos = std::find(widgets.begin(), widgets.end(), this);
-            if (pos != widgets.end())
-                widgets.erase(pos);
-        }
-        event->accept();
-    }
 };
 
 #endif // MAINWINDOW_H

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -60,6 +60,21 @@ private:
     std::unique_ptr<Ui::MainWindow> mUi;
 
     DockWrapper* createWrapperWidget(QWidget* widget, const QString& title = "Dockwidget");
+
+    /**
+     * @brief Create a wrapped Widget object
+     * This works the same as createWrapperWidget, except that it defers the
+     * creation of the widget until after the wrapper dock is created.
+     * @tparam T The type of widget. Must accept the pattern T{QWidget* parent}
+     * @param title The title of the widget
+     * @return DockWrapper* pointer to new wrapped widget
+     */
+    template <typename T>
+    DockWrapper* createWrappedWidget(const QString& title = "Dockwidget") {
+        auto dock = new DockWrapper{title, this};
+        dock->setWidget(new T{dock});
+        return dock;
+    }
     // ALgorithm for finding new dock widget placements.
     void layoutDockWidget(DockWrapper* newWidget);
 

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -168,18 +168,8 @@ void Renderer::rotate(float dx, float dy)
 
     QVector4D transformedAxis = mViewMatrixInverse*QVector4D(rotVec,0.f);
 
-    const auto origMat{view};
     view.rotate(0.5f*rotVec.length(), transformedAxis.toVector3D());
     viewMatrixUpdated();
-
-    // Rotate plane:
-    auto volume = getVolume();
-    if (volume && mIsSlicePlaneEnabled && mIsCameraLinkedToSlicePlane) {
-        const auto relativeTrans = mViewMatrixInverse * origMat;
-        const auto newDir = (relativeTrans * QVector4D{volume->m_slicingGeometry.dir, 0.f}).toVector3D();
-        volume->m_slicingGeometry.dir = newDir;
-        volume->updateSlicingGeometryBuffer();
-    }
 }
 
 Shader& Renderer::shaderProgram(const std::string& name) {

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -38,7 +38,7 @@ public:
     ~Renderer() override;
 
     virtual void zoom(double z);
-    void rotate(float dx, float dy);
+    virtual void rotate(float dx, float dy);
 
     virtual const QMatrix4x4& getViewMatrix() const; 
     virtual std::shared_ptr<Volume> getVolume() const;

--- a/src/renderer2d.cpp
+++ b/src/renderer2d.cpp
@@ -28,7 +28,24 @@ void Renderer2D::rotate(float dx, float dy) {
     if (volume && mIsSlicePlaneEnabled && mIsCameraLinkedToSlicePlane) {
         volume->m_slicingGeometry.dir = (mMVPInverse * QVector4D{0.f, 0.f, -1.f, 0.f}).toVector3D().normalized();
         volume->m_slicingGeometry.pos = (mMVPInverse * QVector4D{0.f, 0.f, 0.f, 1.f}).toVector3D();
+
+        mBlockSliceUpdate = true;
         volume->updateSlicingGeometryBuffer();
+        mBlockSliceUpdate = false;
+    }
+}
+
+void Renderer2D::updateViewMatrixFromSlicingPlane() {
+    if (mBlockSliceUpdate)
+        return;
+        
+    auto volume = getVolume();
+    if (volume) {
+        const auto& plane = volume->m_slicingGeometry;
+        auto& view = getViewMatrix();
+        view.setToIdentity();
+        view.lookAt(plane.pos, plane.pos - plane.dir, {0.f, 1.f, 0.f});
+        viewMatrixUpdated();
     }
 }
 

--- a/src/renderer2d.cpp
+++ b/src/renderer2d.cpp
@@ -7,7 +7,6 @@
 
 void Renderer2D::zoom(double z) {
     auto& view = getViewMatrix();
-    const auto& origMat{view};
 
     auto& trans = view(2,3);
     const auto delta = std::clamp(trans + static_cast<float>(z) * 0.02f, -1.f, 1.f) - trans;
@@ -16,10 +15,19 @@ void Renderer2D::zoom(double z) {
 
     auto volume = getVolume();
     if (volume && mIsSlicePlaneEnabled && mIsCameraLinkedToSlicePlane) {
-        auto& plane = volume->m_slicingGeometry;
-        const auto dir = (mViewMatrixInverse * QVector4D{0.f, 0.f, 1.f, 0.f}).toVector3D();
-        const auto newPos = plane.pos + dir * delta;
-        plane.pos = QVector3D::dotProduct(newPos, plane.dir) * plane.dir;
+        auto pos = (mMVPInverse * QVector4D{0.f, 0.f, 0.f, 1.f}).toVector3D();
+        volume->m_slicingGeometry.pos = pos;
+        volume->updateSlicingGeometryBuffer();
+    }
+}
+
+void Renderer2D::rotate(float dx, float dy) {
+    Renderer::rotate(dx, dy);
+
+    auto volume = getVolume();
+    if (volume && mIsSlicePlaneEnabled && mIsCameraLinkedToSlicePlane) {
+        volume->m_slicingGeometry.dir = (mMVPInverse * QVector4D{0.f, 0.f, -1.f, 0.f}).toVector3D().normalized();
+        volume->m_slicingGeometry.pos = (mMVPInverse * QVector4D{0.f, 0.f, 0.f, 1.f}).toVector3D();
         volume->updateSlicingGeometryBuffer();
     }
 }
@@ -71,11 +79,6 @@ void Renderer2D::paintGL() {
     if (volume) {
         shader.setUniformValue("volumeScale", volume->volumeScale());
         shader.setUniformValue("volumeSpacing", volume->volumeSpacing());
-        if (mIsCameraLinkedToSlicePlane) {
-            auto& plane = volume->m_slicingGeometry;
-            viewMatrix.lookAt(plane.pos, plane.pos + plane.dir, {0.f, 1.f, 0.f});
-            shader.setUniformValue("MVP", (mPerspectiveMatrix * viewMatrix).inverted());
-        }
 
         // Volume guard automatically binds and unbinds. :)
         volumeGuard = volume->guard();

--- a/src/renderer2d.h
+++ b/src/renderer2d.h
@@ -10,10 +10,17 @@ public:
     void zoom(double z) override;
     void rotate(float dx, float dy) override;
 
+public slots:
+    void updateViewMatrixFromSlicingPlane();
+
 protected:
     void initializeGL() override;
     void paintGL() override;
     void resizeGL(int w, int h) override;
+
+private:
+    bool mBlockSliceUpdate{false};
+    
 };
 
 #endif // RENDERER3D_H

--- a/src/renderer2d.h
+++ b/src/renderer2d.h
@@ -8,6 +8,7 @@ public:
     Renderer2D(QWidget *parent = nullptr) : Renderer{parent} {}
 
     void zoom(double z) override;
+    void rotate(float dx, float dy) override;
 
 protected:
     void initializeGL() override;

--- a/src/renderer3d.cpp
+++ b/src/renderer3d.cpp
@@ -26,6 +26,21 @@ bool Renderer3D::isGlobeIntersecting(const QVector2D& p) const {
     return (p - globePosition()).length() <= mGlobe.mRadius;
 }
 
+void Renderer3D::rotate(float dx, float dy) {
+    const auto origMat{getViewMatrix()};
+
+    Renderer::rotate(dx, dy);
+
+    // Rotate plane:
+    auto volume = getVolume();
+    if (volume && mIsSlicePlaneEnabled && mIsCameraLinkedToSlicePlane) {
+        const auto relativeTrans = mViewMatrixInverse * origMat;
+        const auto newDir = (relativeTrans * QVector4D{volume->m_slicingGeometry.dir, 0.f}).toVector3D();
+        volume->m_slicingGeometry.dir = newDir;
+        volume->updateSlicingGeometryBuffer();
+    }
+}
+
 void Renderer3D::initializeGL() {
     Renderer::initializeGL();
 

--- a/src/renderer3d.h
+++ b/src/renderer3d.h
@@ -30,6 +30,8 @@ public:
     QVector2D globePosition() const;
     bool isGlobeIntersecting(const QVector2D& p) const;
 
+    void rotate(float dx, float dy) override;
+
 protected:
     void initializeGL() override;
     void paintGL() override;

--- a/src/viewport2d.cpp
+++ b/src/viewport2d.cpp
@@ -135,7 +135,8 @@ void Viewport2D::setAxis(QAction* axis) {
                 if (volume) {
                     const auto& plane = volume->m_slicingGeometry;
                     auto& viewMat = mRenderer->getViewMatrix();
-                    viewMat.lookAt(plane.pos, plane.pos + plane.dir, {0.f, 1.f, 0.f});
+                    viewMat.setToIdentity();
+                    viewMat.lookAt(plane.pos, plane.pos - plane.dir, {0.f, 1.f, 0.f});
                     mRenderer->viewMatrixUpdated();
                 }
             }

--- a/src/viewport2d.h
+++ b/src/viewport2d.h
@@ -43,6 +43,7 @@ private:
     QAction* mRemoveVolumeAction{nullptr};
     std::vector<QAction*> mAxisActions;
     AxisMode mAxisMode{AxisMode::ORTHOGONAL};
+    QMetaObject::Connection mSliceUpdateConnection;
 
 private slots:
     void setAxis(QAction* axis);

--- a/src/viewport3d.cpp
+++ b/src/viewport3d.cpp
@@ -9,6 +9,7 @@
 #include <QLabel>
 #include "renderutils.h"
 #include <QMenuBar>
+#include <QShortcut>
 
 Viewport3D::Viewport3D(QWidget *parent) :
     QWidget{parent}, IMenu{this}
@@ -17,12 +18,33 @@ Viewport3D::Viewport3D(QWidget *parent) :
     mLayout = new QVBoxLayout{this};
     mLayout->setContentsMargins(0, 0, 0, 0);
 
+    // Shortcuts:
+    const auto sliceKeys = QKeySequence{tr("S", "Toggle slice")};
+    const auto mvTglKeys = QKeySequence{tr("L", "Toggle linked to camera")};
+
     // Slice menu
     auto slicemenu = mMenuBar->addMenu("Slicing");
     auto sliceEnable = slicemenu->addAction("Enable");
     sliceEnable->setCheckable(true);
+    // This shortcut will actually never be run because widget can never get focus,
+    // but I want the shortcut to be there. (hacky solution, but you can't argue with the results)
+    sliceEnable->setShortcut(sliceKeys);
+    sliceEnable->setShortcutContext(Qt::ShortcutContext::WidgetShortcut);
+
+    auto sliceEnableProxyShortcut = new QShortcut{sliceKeys, parent};
+    sliceEnableProxyShortcut->setContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
+    connect(sliceEnableProxyShortcut, &QShortcut::activated, sliceEnable, &QAction::toggle);
+
     mSliceMoveToggle = slicemenu->addAction("Linked to camera");
     mSliceMoveToggle->setCheckable(true);
+    // Again, just a fake shortcut:
+    mSliceMoveToggle->setShortcut(mvTglKeys);
+    mSliceMoveToggle->setShortcutContext(Qt::ShortcutContext::WidgetShortcut);
+
+    // Actual shortcut:
+    auto sliceMoveToggleProxyShortcut = new QShortcut{mvTglKeys, parent};
+    sliceMoveToggleProxyShortcut->setContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
+    connect(sliceMoveToggleProxyShortcut, &QShortcut::activated, mSliceMoveToggle, &QAction::toggle);
 
     // Opacity slider menu widget:
     auto sliceSlider = new QWidgetAction{this};

--- a/src/volume.cpp
+++ b/src/volume.cpp
@@ -358,6 +358,8 @@ void Volume::updateSlicingGeometryBuffer() {
     };
     glBufferSubData(GL_SHADER_STORAGE_BUFFER, 0, 8 * sizeof(GLfloat), values);
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+
+    slicingGeometryUpdated();
 }
 
 void Volume::updateSlicingGeometryBuffer(const Plane& geometry) {

--- a/src/volume.h
+++ b/src/volume.h
@@ -68,6 +68,7 @@ public:
 signals:
     void loaded();
     void transferFunctionUpdated();
+    void slicingGeometryUpdated();
 
 private:
     unsigned short m_width{0}, m_height{0}, m_depth{0};


### PR DESCRIPTION
 - Fixed #38, so 2d renderer shows same slice.
 - Fixed such that updates in the slice from other sources is reflected in the 2d renderers.
 - Added more shortcuts for slicing (<kbd>S</kbd> for enabling/disabling slicing and <kbd>L</kbd> for linking/unlinking to camera)